### PR TITLE
GUI improvements in preference pages

### DIFF
--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/preferences/GeneralPage.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/preferences/GeneralPage.java
@@ -44,6 +44,8 @@ public class GeneralPage extends PreferencePage implements IWorkbenchPreferenceP
 	private Button bt_contOnError;
 	private Button bt_showErrors;
 	
+	private Composite content;
+	
     public GeneralPage() {
         super();
         setPreferenceStore(ActionsUIPlugin.getDefault().getPreferenceStore());
@@ -91,71 +93,15 @@ public class GeneralPage extends PreferencePage implements IWorkbenchPreferenceP
 		return (ActionView)PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().findViewReference(ActionView.ID).getPart(false); 
 	}
 
-	protected void createFieldEditors(Composite parent) {
-        GridData gridData = new GridData();
-        gridData.horizontalAlignment = GridData.FILL;
-        gridData.grabExcessHorizontalSpace = true;
-        
-        Group layoutGroup = new Group(parent, SWT.NONE);
-        layoutGroup.setText(Messages.GeneralPage_1);
-        layoutGroup.setLayoutData(gridData);
-        layoutGroup.setLayout(new GridLayout());
-        
-        bt_showFilenames = new Button(layoutGroup, SWT.CHECK);
-        bt_showFilenames.setText(Messages.GeneralPage_3);
-        bt_showFilenames.setLayoutData(gridData);
-        bt_showFilenames.setSelection(showFilenames);
-
-        gridData = new GridData();
-        gridData.horizontalAlignment = GridData.FILL;
-        gridData.grabExcessHorizontalSpace = true;
-
-        Group securityGroup = new Group(parent, SWT.NONE);
-        securityGroup.setText(Messages.GeneralPage_2);
-        securityGroup.setLayoutData(gridData);
-        securityGroup.setLayout(new GridLayout());
-        
-        bt_storePasswords = new Button(securityGroup, SWT.CHECK);
-        bt_storePasswords.setText(Messages.GeneralPage_4);
-        bt_storePasswords.setLayoutData(gridData);
-        bt_storePasswords.setSelection(storePasswords);
-
-        gridData = new GridData();
-        gridData.horizontalAlignment = GridData.FILL;
-        gridData.grabExcessHorizontalSpace = true;
-
-        Group errorHandlingGroup = new Group(parent, SWT.NONE);
-        errorHandlingGroup.setText(Messages.GeneralPage_5);
-        errorHandlingGroup.setLayoutData(gridData);
-        errorHandlingGroup.setLayout(new GridLayout());
-
-        bt_contOnError = new Button(errorHandlingGroup, SWT.CHECK);
-        bt_contOnError.setText(Messages.GeneralPage_6);
-        bt_contOnError.setLayoutData(gridData);
-        bt_contOnError.addListener(SWT.Selection, this);
-        bt_contOnError.setSelection(contOnError);
-        
-        bt_showErrors = new Button(errorHandlingGroup, SWT.CHECK);
-        bt_showErrors.setText(Messages.GeneralPage_7);
-        bt_showErrors.setLayoutData(gridData);
-        bt_showErrors.setSelection(showErrors);
-        
-        if (bt_contOnError.getSelection())
-			bt_showErrors.setEnabled(true);
-		else {
-			bt_showErrors.setEnabled(false);
-		}
-			
-        
-    }
-
-    public void init(IWorkbench workbench) {
+    @Override
+	public void init(IWorkbench workbench) {
     	showErrors = ActionsUIPlugin.getDefault().getPreferenceStore().getBoolean(PreferenceConstants.P_DONT_SHOW_MESSAGES);
     	contOnError =  ActionsUIPlugin.getDefault().getPreferenceStore().getBoolean(PreferenceConstants.P_IGNORE_ERRORS);
     	showFilenames = ActionsUIPlugin.getDefault().getPreferenceStore().getBoolean(PreferenceConstants.P_SHOW_FILENAMES);
     	storePasswords = ActionsUIPlugin.getDefault().getPreferenceStore().getBoolean(PreferenceConstants.P_STORE_PASSWORDS);
     }
 
+	@Override
 	public void handleEvent(Event event) {
 		if (event.widget == bt_contOnError){
 			if (bt_contOnError.getSelection())
@@ -163,12 +109,55 @@ public class GeneralPage extends PreferencePage implements IWorkbenchPreferenceP
 			else
 				bt_showErrors.setEnabled(false);
 		}
-		
 	}
 
 	@Override
 	protected Control createContents(Composite parent) {
-		createFieldEditors(parent);
-		return null;
+        content = new Composite(parent, SWT.NONE);
+        content.setLayout(new GridLayout());
+        
+        Group layoutGroup = new Group(content, SWT.NONE);
+        layoutGroup.setText(Messages.GeneralPage_1);
+        layoutGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+        layoutGroup.setLayout(new GridLayout());
+        
+        bt_showFilenames = new Button(layoutGroup, SWT.CHECK);
+        bt_showFilenames.setText(Messages.GeneralPage_3);
+        bt_showFilenames.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+        bt_showFilenames.setSelection(showFilenames);
+
+        Group securityGroup = new Group(content, SWT.NONE);
+        securityGroup.setText(Messages.GeneralPage_2);
+        securityGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+        securityGroup.setLayout(new GridLayout());
+        
+        bt_storePasswords = new Button(securityGroup, SWT.CHECK);
+        bt_storePasswords.setText(Messages.GeneralPage_4);
+        bt_storePasswords.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+        bt_storePasswords.setSelection(storePasswords);
+
+        Group errorHandlingGroup = new Group(content, SWT.NONE);
+        errorHandlingGroup.setText(Messages.GeneralPage_5);
+        errorHandlingGroup.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+        errorHandlingGroup.setLayout(new GridLayout());
+
+        bt_contOnError = new Button(errorHandlingGroup, SWT.CHECK);
+        bt_contOnError.setText(Messages.GeneralPage_6);
+        bt_contOnError.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+        bt_contOnError.addListener(SWT.Selection, this);
+        bt_contOnError.setSelection(contOnError);
+        
+        bt_showErrors = new Button(errorHandlingGroup, SWT.CHECK);
+        bt_showErrors.setText(Messages.GeneralPage_7);
+        bt_showErrors.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
+        bt_showErrors.setSelection(showErrors);
+        
+        if (bt_contOnError.getSelection())
+			bt_showErrors.setEnabled(true);
+		else {
+			bt_showErrors.setEnabled(false);
+		}
+        
+        return content;
 	}
 }

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/preferences/messages.properties
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/preferences/messages.properties
@@ -1,4 +1,4 @@
-GeneralPage_0=Preferences for the Actions view.
+GeneralPage_0=Preferences for the Actions view
 GeneralPage_1=Layout
 GeneralPage_2=Security
 GeneralPage_3=Show filenames in the Actions view

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/preferences/messages_de.properties
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/preferences/messages_de.properties
@@ -1,4 +1,4 @@
-GeneralPage_0=Einstellungen f\u00fcr die Aktionen-Sicht.
+GeneralPage_0=Einstellungen f\u00fcr die Aktionen-Sicht
 GeneralPage_1=Aussehen
 GeneralPage_2=Sicherheit
 GeneralPage_3=Dateinamen in der Aktionen-Sicht anzeigen

--- a/org.jcryptool.core.logging/src/org/jcryptool/core/logging/preferences/pages/LoggerPage.java
+++ b/org.jcryptool.core.logging/src/org/jcryptool/core/logging/preferences/pages/LoggerPage.java
@@ -94,17 +94,20 @@ public class LoggerPage extends PreferencePage implements IWorkbenchPreferencePa
             loglevel = LogUtil.getLogLevel();
     }
 
-    protected IPreferenceStore doGetPreferenceStore() {
+    @Override
+	protected IPreferenceStore doGetPreferenceStore() {
         return LoggingPlugin.getDefault().getPreferenceStore();
     }
 
-    protected void performDefaults() {
+    @Override
+	protected void performDefaults() {
         setDefaultLogLevel();
         refreshWidgets();
         super.performDefaults();
     }
 
-    public boolean performOk() {
+    @Override
+	public boolean performOk() {
         if (btError.getSelection()) {
             doGetPreferenceStore().setValue(LogUtil.LOGGER_LOG_LEVEL, IStatus.ERROR);
             LogUtil.setLogLevel(IStatus.ERROR);
@@ -118,7 +121,8 @@ public class LoggerPage extends PreferencePage implements IWorkbenchPreferencePa
         return super.performOk();
     }
 
-    public void init(IWorkbench workbench) {
+    @Override
+	public void init(IWorkbench workbench) {
         setDefaultLogLevel();
     }
 }

--- a/org.jcryptool.core.logging/src/org/jcryptool/core/logging/preferences/pages/LoggerPage.java
+++ b/org.jcryptool.core.logging/src/org/jcryptool/core/logging/preferences/pages/LoggerPage.java
@@ -28,10 +28,11 @@ import org.jcryptool.core.logging.LoggingPlugin;
 import org.jcryptool.core.logging.utils.LogUtil;
 
 public class LoggerPage extends PreferencePage implements IWorkbenchPreferencePage {
-    private GridLayout layout;
+	
     private Button btError;
     private Button btWarn;
     private Button btInfo;
+    private Composite content;
     private Label lbError;
     private Label lbWarn;
     private Label lbInfo;
@@ -44,21 +45,12 @@ public class LoggerPage extends PreferencePage implements IWorkbenchPreferencePa
 
     @Override
     protected Control createContents(Composite parent) {
-        Composite content = new Composite(parent, SWT.NONE);
-
-        GridData gridData = new GridData();
-        gridData.horizontalAlignment = GridData.FILL;
-        gridData.grabExcessHorizontalSpace = true;
-
-        layout = new GridLayout(1, false);
-        layout.marginHeight = 0;
-        layout.marginWidth = 0;
-        content.setLayout(layout);
+        content = new Composite(parent, SWT.NONE);
+        content.setLayout(new GridLayout());
 
         Group gLoglevel = new Group(content, SWT.SHADOW_ETCHED_IN);
-        gLoglevel.setSize(110, 75);
         gLoglevel.setText(Messages.loglevel);
-        gLoglevel.setLayoutData(gridData);
+        gLoglevel.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         gLoglevel.setLayout(new GridLayout(2, false));
 
         btError = new Button(gLoglevel, SWT.RADIO);

--- a/org.jcryptool.core.logging/src/org/jcryptool/core/logging/preferences/pages/messages.properties
+++ b/org.jcryptool.core.logging/src/org/jcryptool/core/logging/preferences/pages/messages.properties
@@ -1,5 +1,5 @@
 leglevel_error=Error
-LoggingPage_0=Settings for the logging.
+LoggingPage_0=Settings for the logging
 loglevel=Log-Level
 loglevel_error_description=Log error messages only
 loglevel_info=Info

--- a/org.jcryptool.core.logging/src/org/jcryptool/core/logging/preferences/pages/messages_de.properties
+++ b/org.jcryptool.core.logging/src/org/jcryptool/core/logging/preferences/pages/messages_de.properties
@@ -1,5 +1,5 @@
 leglevel_error=Fehler
-LoggingPage_0=Einstellungen f\u00fcr das Logging.
+LoggingPage_0=Einstellungen f\u00fcr das Logging
 loglevel=Log-Level
 loglevel_error_description=Nur Fehlermeldungen loggen
 loglevel_info=Info

--- a/org.jcryptool.core/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.core/OSGI-INF/l10n/bundle.properties
@@ -41,11 +41,10 @@ action.openfile=Open File...
 command.openfile=Open File
 product.description=The cryptography e-learning platform.
 product.name=JCrypTool
-about.text=JCrypTool \u2016 the cryptography e-learning platform\n\
-JCrypTool is an extendable e-learning platform presenting cryptography,\n\
-cryptanalysis and IT-Security in a modern and easy-to-use fashion.\n\
-JCrypTool is built as platform-independent open source software\n\
-and is part of the open source project CrypTool.\n\
+about.text=JCrypTool \u2013 the cryptography e-learning platform\n\
+JCrypTool is an extendable e-learning platform presenting cryptography, cryptanalysis and IT security in a modern and easy-to-use fashion.\n\
+\n\
+JCrypTool is built as platform-independent open source software and is part of the open-source project CrypTool.\n\
 \n\
 Version: {0}\n\
 Build ID: {1}\n\

--- a/org.jcryptool.core/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.core/OSGI-INF/l10n/bundle_de.properties
@@ -41,11 +41,10 @@ action.openfile=Datei \u00f6ffnen...
 command.openfile=Datei \u00f6ffnen
 product.description=The cryptography e-learning platform.
 product.name=JCrypTool
-about.text=JCrypTool \u2016 the cryptography e-learning platform\n\
-JCrypTool ist eine moderne und umfangreich erweiterbare E-Learning-\n\
-Plattform rund um die Themen Kryptografie, Kryptoanalyse und IT-Sicherheit.\n\
-JCrypTool wird als Plattform-unabh\u00e4ngige und kostenlose Software\n\
-zur Verf\u00fcgung gestellt und ist Teil des Open-Source-Projektes CrypTool.\n\
+about.text=JCrypTool \u2013 the cryptography e-learning platform\n\
+JCrypTool ist eine moderne und umfangreich erweiterbare E-Learning-Plattform rund um die Themen Kryptografie, Kryptoanalyse und IT-Sicherheit.\n\
+\n\
+JCrypTool wird als Plattform-unabh\u00e4ngige und kostenlose Software zur Verf\u00fcgung gestellt und ist Teil des Open-Source-Projektes CrypTool.\n\
 \n\
 Version: {0}\n\
 Build ID: {1}\n\

--- a/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/AlgorithmsPage.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/AlgorithmsPage.java
@@ -27,7 +27,7 @@ public class AlgorithmsPage extends FieldEditorPreferencePage implements IWorkbe
     public AlgorithmsPage() {
         super(GRID);
         setPreferenceStore(CorePlugin.getDefault().getPreferenceStore());
-        setDescription(Messages.AlgorithmsPage_0);
+//        setDescription(Messages.AlgorithmsPage_0);
     }
 
     @Override

--- a/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/AnalysisPage.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/AnalysisPage.java
@@ -27,7 +27,7 @@ public class AnalysisPage extends FieldEditorPreferencePage implements IWorkbenc
     public AnalysisPage() {
         super(GRID);
         setPreferenceStore(CorePlugin.getDefault().getPreferenceStore());
-        setDescription(Messages.AnalysisPage_0);
+//        setDescription(Messages.AnalysisPage_0);
     }
 
     @Override

--- a/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/GamesPage.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/GamesPage.java
@@ -27,7 +27,7 @@ public class GamesPage extends FieldEditorPreferencePage implements IWorkbenchPr
     public GamesPage() {
         super(GRID);
         setPreferenceStore(CorePlugin.getDefault().getPreferenceStore());
-        setDescription(Messages.Games_0);
+//        setDescription(Messages.Games_0);
     }
 
     @Override

--- a/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/GeneralPage.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/GeneralPage.java
@@ -68,7 +68,6 @@ public class GeneralPage extends FieldEditorPreferencePage implements IWorkbench
     public GeneralPage() {
         super(GRID);
         setPreferenceStore(CorePlugin.getDefault().getPreferenceStore());
-        setDescription(Messages.General_0);
         IExtensionPoint p = Platform.getExtensionRegistry().getExtensionPoint("org.jcryptool.core.platformLanguage"); //$NON-NLS-1$
         IExtension[] ext = p.getExtensions();
         nl = new String[ext.length];
@@ -95,13 +94,9 @@ public class GeneralPage extends FieldEditorPreferencePage implements IWorkbench
 
     @Override
     protected Control createContents(Composite parent) {
-        GridData gridData = new GridData();
-        gridData.horizontalAlignment = GridData.FILL;
-        gridData.grabExcessHorizontalSpace = true;
-
         Group gLanguage = new Group(parent, SWT.NONE);
         gLanguage.setText(Messages.SelectLanguage);
-        gLanguage.setLayoutData(gridData);
+        gLanguage.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         gLanguage.setLayout(new GridLayout());
 
         listLanguage = new Combo(gLanguage, SWT.BORDER | SWT.SINGLE | SWT.READ_ONLY);
@@ -116,17 +111,16 @@ public class GeneralPage extends FieldEditorPreferencePage implements IWorkbench
             listLanguage.select(0);
         }
 
-        GridData gridData2 = new GridData();
-        gridData2.horizontalAlignment = GridData.FILL;
-        gridData2.grabExcessHorizontalSpace = true;
-
         Group gLocation = new Group(parent, SWT.NONE);
         gLocation.setText(Messages.WorkspaceLocation);
-        gLocation.setLayoutData(gridData2);
+        GridData gd_gLocation = new GridData(SWT.FILL, SWT.FILL, true, false);
+        gd_gLocation.verticalIndent = 30;
+        gLocation.setLayoutData(gd_gLocation);
         gLocation.setLayout(new GridLayout());
         
         lblLocation = new Label(gLocation, SWT.BORDER | SWT.SINGLE | SWT.READ_ONLY);
         lblLocation.setText(currentLocation);
+        lblLocation.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, false));
         
         return super.createContents(parent);
     }

--- a/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/VisualsPage.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/VisualsPage.java
@@ -27,7 +27,7 @@ public class VisualsPage extends FieldEditorPreferencePage implements IWorkbench
     public VisualsPage() {
         super(GRID);
         setPreferenceStore(CorePlugin.getDefault().getPreferenceStore());
-        setDescription(Messages.VisualsPage_0);
+//        setDescription(Messages.VisualsPage_0);
     }
 
     @Override

--- a/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/messages_de.properties
+++ b/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/messages_de.properties
@@ -8,6 +8,6 @@ MessageError=Umstellen der Sprache ist nicht m\u00F6glich.
 MessageLogRestart=Neustart wegen Sprach\u00E4nderung angefordert.
 MessageRestart=Die \u00C4nderung der Spracheinstellungen erfordert einen Neustart. M\u00F6chten Sie JCrypTool neu starten?
 MessageTitleRestart=Neustart erforderlich
-SelectLanguage=JCrypTool Sprache
+SelectLanguage=JCrypTool-Sprache
 WorkspaceLocation=Speicherort des Workspace
 VisualsPage_0=Klappen Sie den Baum auf, um die Einstellungen f\u00fcr eine bestimmte Visualisierung zu bearbeiten.

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/preferences/messages.properties
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/preferences/messages.properties
@@ -1,4 +1,4 @@
-GeneralPreferencePage_0=Preferences for the File Explorer.
+GeneralPreferencePage_0=Preferences for the File Explorer
 GeneralPreferencePage_1=Start &directory:
 GeneralPreferencePage_2=Open &source file before cryptographic operation
 GeneralPreferencePage_3=Open &target file after cryptographic operation

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/preferences/messages_de.properties
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/preferences/messages_de.properties
@@ -1,4 +1,4 @@
-GeneralPreferencePage_0=Benutzervorgaben f\u00fcr den Datei-Explorer.
+GeneralPreferencePage_0=Benutzervorgaben f\u00fcr den Datei-Explorer
 GeneralPreferencePage_1=&Startverzeichnis:
 GeneralPreferencePage_2=&Quelle vor der kryptografischen Operation \u00f6ffnen
 GeneralPreferencePage_3=&Ziel nach der kryptografischen Operation \u00f6ffnen


### PR DESCRIPTION
I removed the "Expand the tree ..." text from settings pages where there were no more preference pages.
<img width="334" alt="preference_algorithms_old" src="https://user-images.githubusercontent.com/20046726/34046883-d107c7ae-e1ae-11e7-9a4f-f827798797e0.PNG">
<img width="334" alt="preference_algorithms_new" src="https://user-images.githubusercontent.com/20046726/34046885-d217c126-e1ae-11e7-9964-dd8f4141cbeb.PNG">
I tried to remove the buttons from the empty pages. I have not figured out how to do this.

The others changes are marked in the screenshots below.
<img width="334" alt="preference_general_old" src="https://user-images.githubusercontent.com/20046726/34047112-7a19a9c0-e1af-11e7-90b4-636fe015e36c.PNG">
<img width="334" alt="preference_general_new" src="https://user-images.githubusercontent.com/20046726/34047114-7b2720f4-e1af-11e7-88a1-521e1a4dab04.PNG">
<img width="334" alt="preference_actions_old" src="https://user-images.githubusercontent.com/20046726/34047171-ae07c622-e1af-11e7-85c7-fbf2831bc6db.PNG">
<img width="355" alt="preference_actions_new" src="https://user-images.githubusercontent.com/20046726/34047175-af2c77b4-e1af-11e7-942f-6653e9ae6765.PNG">

I tried to edit the about the jct text. I changed the text in the bundle.properties but it did not change the text that is displayed. At first I thought the text would be cached and deleted the .jcryptool folder. That did not help. Does anyone have an idea why the changed text is not displayed? Maybe the problem fixes itself when the next Weekly Build comes out.
<img width="523" alt="about_old" src="https://user-images.githubusercontent.com/20046726/34047340-3fbad744-e1b0-11e7-9658-fa0708bfe7d6.PNG">
I also tried to make the headline bold. That did not work, because html code seems to be ignored. I tried \<b> and \<strong>.


