### PR TITLE
Added Keystore Icon to the toolbar

### DIFF
--- a/org.jcryptool.crypto.keystore/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.crypto.keystore/OSGI-INF/l10n/bundle.properties
@@ -19,3 +19,5 @@ properties.command.description = Shows properties of the selected key.
 properties.command.tooltip = Shows properties of the selected key.
 selectkey.command.description=Select key from the keystore.
 selectkey.command.name=Select key
+openkeystore.command.name=Open Keystore
+openkeystore.command.description=Open Keystore

--- a/org.jcryptool.crypto.keystore/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.crypto.keystore/OSGI-INF/l10n/bundle_de.properties
@@ -19,3 +19,5 @@ properties.command.description=Zeigt die Eigenschaften des ausgew\u00E4hlten Sch
 properties.command.tooltip=Zeigt die Eigenschaften des ausgew\u00E4hlten Schl\u00FCssels.
 selectkey.command.name=Schl\u00FCssel ausw\u00e4hlen
 selectkey.command.description=Schl\u00FCssel aus dem Schl\u00FCsselspeicher ausw\u00E4hlen.
+openkeystore.command.name=Schl\u00fcsselspeicher \u00f6ffnen
+openkeystore.command.description=Schl\u00fcsselspeicher \u00f6ffnen

--- a/org.jcryptool.crypto.keystore/plugin.xml
+++ b/org.jcryptool.crypto.keystore/plugin.xml
@@ -15,8 +15,7 @@
             icon="icons/16x16/kgpg_info.png"
             category="org.jcryptool.crypto"
             class="org.jcryptool.crypto.keystore.ui.views.KeystoreView"
-            id="org.jcryptool.crypto.keystore.KeystoreView"
-            >
+            id="org.jcryptool.crypto.keystore.KeystoreView">
       </view>
    </extension>
    <extension point="org.eclipse.help.contexts">
@@ -66,6 +65,15 @@
             </visibleWhen>
       </command>
     </menuContribution>
+    <menuContribution
+    	allPopups="false"
+    	locationURI="toolbar:org.jcryptool.core.toolbar?after=additions">
+    	<command
+    		commandId="org.jcryptool.crypto.keystore.OpenKeystore"
+    		icon="icons/16x16/kgpg_info.png"
+    		style="push">
+    	</command>
+    </menuContribution>
  </extension>
  <extension
        point="org.eclipse.ui.commands">
@@ -79,12 +87,21 @@
             id="org.jcryptool.crypto.keystore.SelectKey"
             name="%selectkey.command.name">
       </command>
+      <command
+      		description="%openkeystore.command.description"
+      		id="org.jcryptool.crypto.keystore.OpenKeystore"
+      		name="%openkeystore.command.name">
+      </command>
  </extension>
  <extension
        point="org.eclipse.ui.handlers">
     <handler
-          class="org.jcryptool.crypto.keystore.commands.ShowPropertiesHandler"
-          commandId="org.jcryptool.crypto.keystore.ShowProperties">
+    	class="org.jcryptool.crypto.keystore.commands.ShowPropertiesHandler"
+    	commandId="org.jcryptool.crypto.keystore.ShowProperties">
+    </handler>
+    <handler
+    	class="org.jcryptool.crypto.keystore.commands.OpenKeystoreHandler"
+    	commandId="org.jcryptool.crypto.keystore.OpenKeystore">
     </handler>
  </extension>
 </plugin>

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/commands/OpenKeystoreHandler.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/commands/OpenKeystoreHandler.java
@@ -1,0 +1,32 @@
+package org.jcryptool.crypto.keystore.commands;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.jcryptool.core.logging.utils.LogUtil;
+import org.jcryptool.crypto.keystore.KeyStorePlugin;
+
+/**
+ * A Handler to open the keystore from the icon in the toolbar. Opens the same view as 
+ * Window -> Show View -> Other ... ->Cryptography -> Keystore.
+ * @author Thorben Groos
+ *
+ */
+public class OpenKeystoreHandler extends AbstractHandler {
+
+	@Override
+	public Object execute(ExecutionEvent event) throws ExecutionException {
+		try {
+			PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage()
+			.showView("org.jcryptool.crypto.keystore.KeystoreView");
+		} catch (PartInitException e) {
+			LogUtil.logError(KeyStorePlugin.PLUGIN_ID, e);
+		}
+		
+		
+		return null;
+	}
+
+}

--- a/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/BrowserPlugin.java
+++ b/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/BrowserPlugin.java
@@ -17,6 +17,7 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
  */
 public class BrowserPlugin extends AbstractUIPlugin {
 	
+	
     /** The plug-in ID. */
     public static final String PLUGIN_ID = "org.jcryptool.webbrowser"; //$NON-NLS-1$
 


### PR DESCRIPTION
As already written in the title, I added a shortcut to the keystore to the toolbar.


<img width="483" alt="newicon_1" src="https://user-images.githubusercontent.com/20046726/41367660-f4e0277e-6f3f-11e8-9035-0ec4adf3cf15.png">


Pressing the icon opens the keystore.
<img width="743" alt="openkeystore_1" src="https://user-images.githubusercontent.com/20046726/41367643-eaef7594-6f3f-11e8-8bb4-ec4548b46ba6.png">

