### PR TITLE
French added as language.

### DIFF
--- a/org.jcryptool.core/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.core/OSGI-INF/l10n/bundle.properties
@@ -13,6 +13,7 @@ bundleName=Core
 intro.title=Welcome
 language.languageEnglish=English
 language.languageGerman=German
+language.languageFrench=French
 menu.label = Help
 command.label = Check for Updates
 command.label.0 = Install New Software...

--- a/org.jcryptool.core/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.core/OSGI-INF/l10n/bundle_de.properties
@@ -13,6 +13,7 @@ bundleName=Core
 intro.title=Willkommen
 language.languageEnglish=Englisch
 language.languageGerman=Deutsch
+language.languageFrench=Franz\u00f6sisch
 menu.label = Hilfe
 command.label = Nach Aktualisierungen suchen
 command.label.0 = Neue Erweiterungen installieren...

--- a/org.jcryptool.core/plugin.xml
+++ b/org.jcryptool.core/plugin.xml
@@ -138,6 +138,9 @@
    <extension point="org.jcryptool.core.platformLanguage">
       <language languageCode="de_DE" languageDescription="%language.languageGerman"/>
    </extension>
+   <extension point="org.jcryptool.core.platformLanguage">
+      <language languageCode="fr_FR" languageDescription="%language.languageFrench"/>
+   </extension>
 
    <extension point="org.eclipse.e4.ui.css.swt.theme">
       <theme basestylesheeturi="css/jcryptool.css" id="org.jcryptool.themes.default" label="Default Theme"/>


### PR DESCRIPTION
I have added French as language to the JCT so that the new Frequency Analysis Plugin translation can be used. https://github.com/jcryptool/crypto/pull/177

I just added the following code:
```
   <extension point="org.jcryptool.core.platformLanguage">
      <language languageCode="fr_FR" languageDescription="%language.languageFrench"/>
   </extension>
```
It looks like the little changes will make it enough for the JCT to run in French. 

Can someone look over it if something is missing?