### PR TITLE
Changed standard perspective.

### DIFF
--- a/org.jcryptool.core/plugin.xml
+++ b/org.jcryptool.core/plugin.xml
@@ -204,19 +204,47 @@
 
    <extension point="org.eclipse.ui.perspectiveExtensions">
       <perspectiveExtension targetID="org.jcryptool.core.perspective">
+      <!-- This are the views that are listed in Window -> Show view. All other views
+      are listed under Window -> Show view -> Others.-->
          <perspectiveShortcut id="org.jcryptool.crypto.flexiprovider.ui.perspective.FlexiProviderPerspective"/>
          <viewShortcut id="org.jcryptool.core.views.AlgorithmView"/>
-         <viewShortcut id="org.jcryptool.fileexplorer.views.FileExplorerView"/>
+         <viewShortcut id="org.jcryptool.fileexplorer.views.FileExplorerView"/> 
          <viewShortcut id="org.eclipse.help.ui.HelpView"/>
          <viewShortcut id="org.jcryptool.actions.views.ActionView"/>
-         <view id="org.jcryptool.fileexplorer.views.FileExplorerView" minimized="false" ratio="0.25f" relationship="left" relative="org.eclipse.ui.editorss"/>
-         <view id="org.jcryptool.actions.views.ActionView" minimized="false" ratio="0.25f" relationship="stack" relative="org.jcryptool.fileexplorer.views.FileExplorerView"/>
-         <view id="org.jcryptool.core.views.AlgorithmView" minimized="false" ratio="0.68f" relationship="right" relative="org.eclipse.ui.editorss"/>
-         <view id="org.eclipse.help.ui.HelpView" minimized="false" ratio="0.5" relationship="bottom" relative="org.jcryptool.fileexplorer.views.FileExplorerView"/>
+         
+         <!-- Here you can specify which views should be opened in the standard
+         perspective of the JCT at startup. -->
+         <!-- The following code is an example how you can stack multiple 
+         views to one position(relationship) (left, right, op, bottom). In this example the 
+         ActionView and the FileExplorerView are on the same position relationship=left. -->
+         <view 
+         	id="org.jcryptool.actions.views.ActionView" 
+         	minimized="false" 
+         	ratio="0.25f" 
+         	relationship="left" 
+         	relative="org.eclipse.ui.editorss"/>
+         <view 
+         	id="org.jcryptool.fileexplorer.views.FileExplorerView" 
+         	minimized="false" 
+         	ratio="0.25f" 
+         	relationship="stack" 
+         	relative="org.jcryptool.actions.views.ActionView"/> 
+         <view 
+         	id="org.jcryptool.core.views.AlgorithmView" 
+         	minimized="false" 
+         	ratio="0.68f" 
+         	relationship="right" 
+         	relative="org.eclipse.ui.editorss"/>
+         <view 
+         	id="org.eclipse.help.ui.HelpView" 
+         	minimized="false" 
+         	ratio="0.5" 
+         	relationship="bottom" 
+         	relative="org.jcryptool.actions.views.ActionView"/>
       </perspectiveExtension>
    </extension>
 
-   <!-- here you can add new languages 
+   <!-- here you can add new languages. 
    simply copy the code and adapt ist to the wished language -->
    <extension point="org.jcryptool.core.platformLanguage">
       <language languageCode="en_EN" languageDescription="%language.languageEnglish"/>


### PR DESCRIPTION
In the standard perspective, the action view is now displayed by default on the left edge. Previously, the File Explorer was displayed there.
Old standard perspective:
<img width="618" alt="standard perspective layout old" src="https://user-images.githubusercontent.com/20046726/52441387-c07ee400-2b20-11e9-97a1-a66cfb1fefa9.PNG">
New standard perspective:
<img width="625" alt="standard perspective layout" src="https://user-images.githubusercontent.com/20046726/52441421-caa0e280-2b20-11e9-85f9-74ddfb0f5fe9.PNG">

