### PR TITLE
Current version displayed in JCT title 

### DIFF
--- a/org.jcryptool.core.logging/src/org/jcryptool/core/logging/utils/LogUtil.java
+++ b/org.jcryptool.core.logging/src/org/jcryptool/core/logging/utils/LogUtil.java
@@ -179,8 +179,18 @@ public class LogUtil {
                 logMessage = ex.getMessage();
             }
 
+            // Logging the currently used JCT version.
+            Status versionInfoStatus = new Status(0, "JCT Version Information", 
+            		"Currently used JCT Version: " + 
+            		Platform.getProduct().getDefiningBundle().getVersion() + 
+            		" " + 
+            		Platform.getProduct().getProperty("mavenBuildTimestamp"));
+            Platform.getLog(Platform.getBundle(bundleId)).log(versionInfoStatus);
+            
+            //Logging of the error.
             Status status = new Status(severity, bundleId, logMessage, ex);
             Platform.getLog(Platform.getBundle(bundleId)).log(status);
+
 
             if (showErrorDialog) {
                 JCTMessageDialog.showErrorDialog(status, message);

--- a/org.jcryptool.core.logging/src/org/jcryptool/core/logging/utils/LogUtil.java
+++ b/org.jcryptool.core.logging/src/org/jcryptool/core/logging/utils/LogUtil.java
@@ -34,6 +34,7 @@ import org.jcryptool.core.logging.dialogs.JCTMessageDialog;
 public class LogUtil {
     public static final String LOGGER_LOG_LEVEL = "org.jcryptool.core.logging.logLevel"; //$NON-NLS-1$
     private static int loglevel = IStatus.ERROR;
+    private static boolean jctVersionLogged = false;
 
     /**
      * Sets a new logging level.
@@ -178,14 +179,18 @@ public class LogUtil {
             if (ex != null) {
                 logMessage = ex.getMessage();
             }
+            
+            if (!jctVersionLogged) {
+                // Logging the currently used JCT version.
+                Status versionInfoStatus = new Status(0, "JCT Version Information", 
+                		"Currently used JCT Version: " + 
+                		Platform.getProduct().getDefiningBundle().getVersion() + 
+                		" " + 
+                		Platform.getProduct().getProperty("mavenBuildTimestamp"));
+                Platform.getLog(Platform.getBundle(bundleId)).log(versionInfoStatus);
+                jctVersionLogged = true;
+            }
 
-            // Logging the currently used JCT version.
-            Status versionInfoStatus = new Status(0, "JCT Version Information", 
-            		"Currently used JCT Version: " + 
-            		Platform.getProduct().getDefiningBundle().getVersion() + 
-            		" " + 
-            		Platform.getProduct().getProperty("mavenBuildTimestamp"));
-            Platform.getLog(Platform.getBundle(bundleId)).log(versionInfoStatus);
             
             //Logging of the error.
             Status status = new Status(severity, bundleId, logMessage, ex);

--- a/org.jcryptool.core/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.core/OSGI-INF/l10n/bundle.properties
@@ -71,3 +71,4 @@ JCrypTool includes software developed by:\n\
 - JDOM http://www.jdom.org\n\
 - ThoughtWorks http://www.thoughtworks.com\n\
 - XStream http://xstream.codehaus.org
+maven.timestamp=${timestamp}

--- a/org.jcryptool.core/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.core/OSGI-INF/l10n/bundle_de.properties
@@ -71,3 +71,4 @@ JCrypTool enth\u00e4lt u.a. Software von:\n\
 - JDOM http://www.jdom.org\n\
 - ThoughtWorks http://www.thoughtworks.com\n\
 - XStream http://xstream.codehaus.org
+maven.timestamp=${timestamp}

--- a/org.jcryptool.core/plugin.xml
+++ b/org.jcryptool.core/plugin.xml
@@ -274,7 +274,10 @@
          <property name="startupMessageRect" value="7,238,445,20"/>
          <property name="startupProgressRect" value="5,275,445,15"/>
          <property name="mavenBuildTimestamp" value="%maven.timestamp"/>
-         <property name="preferenceCustomization" value="plugin_customization.ini"/>
+         <property
+               name="preferenceCustomization"
+               value="plugin_customization.ini">
+         </property>
 
       </product>
    </extension>

--- a/org.jcryptool.core/plugin.xml
+++ b/org.jcryptool.core/plugin.xml
@@ -260,22 +260,22 @@
       <theme basestylesheeturi="css/jcryptool.css" id="org.jcryptool.themes.default" label="Default Theme"/>
    </extension>
 
-   <!-- The about window
-        Help -> About -->
+
    <extension id="product" point="org.eclipse.core.runtime.products">
       <product application="org.jcryptool.core.application" name="JCrypTool">
+      <!--  You can access a property via Platform.getProduct().getProperty("appName") -->
          <property name="appName" value="JCrypTool"/>
          <property name="cssTheme" value="org.jcryptool.themes.default"/>
          <property name="aboutImage" value="icons/about_dialog.gif"/>
+            <!-- The about window Help -> About -->
          <property name="aboutText" value="%about.text"/>
          <property name="windowImages" value="icons/icon_16.gif,icons/icon_32.gif,icons/icon_48.gif,icons/icon_64.gif,icons/icon_128.gif,icons/icon_256.gif"/>
          <property name="startupForegroundColor" value="C0C0C0"/>
          <property name="startupMessageRect" value="7,238,445,20"/>
          <property name="startupProgressRect" value="5,275,445,15"/>
-         <property
-               name="preferenceCustomization"
-               value="plugin_customization.ini">
-         </property>
+         <property name="mavenBuildTimestamp" value="%maven.timestamp"/>
+         <property name="preferenceCustomization" value="plugin_customization.ini"/>
+
       </product>
    </extension>
 

--- a/org.jcryptool.core/src/org/jcryptool/core/ApplicationWorkbenchWindowAdvisor.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/ApplicationWorkbenchWindowAdvisor.java
@@ -9,6 +9,7 @@
 // -----END DISCLAIMER-----
 package org.jcryptool.core;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.dialogs.TrayDialog;
 import org.eclipse.swt.dnd.FileTransfer;
 import org.eclipse.swt.graphics.Point;
@@ -60,6 +61,14 @@ public class ApplicationWorkbenchWindowAdvisor extends WorkbenchWindowAdvisor {
 
     	configurer.addEditorAreaTransfer(FileTransfer.getInstance());
     	configurer.configureEditorAreaDropListener(new EditorAreaDropTargetListener());
+    	
+    	//Add to the title you enter in the jcryptool.product file the Version of the JCT (that is also
+    	//entered in the jcryptool.product file) and the maven build timestamp.
+    	configurer.setTitle(Platform.getProduct().getName()
+    			+ " "
+    			+ Platform.getProduct().getDefiningBundle().getVersion()
+    			+ " "
+    			+ Platform.getProduct().getProperty("mavenBuildTimestamp"));
         
         PlatformUI.getPreferenceStore().setValue(IWorkbenchPreferenceConstants.PERSPECTIVE_BAR_EXTRAS, Perspective.PERSPECTIVE_ID
                 + ", org.jcryptool.crypto.flexiprovider.ui.perspective.FlexiProviderPerspective"); //$NON-NLS-1$

--- a/org.jcryptool.releng/pom.xml
+++ b/org.jcryptool.releng/pom.xml
@@ -127,7 +127,7 @@ Maven 3 and Java 8 are required for the build. See https://github.com/jcryptool/
 			<!-- default build creates the weekly build, to create a release use: mvn clean package -P release -->
 			<id>release</id>
 			<properties>
-				<timestamp>${maven.build.timestamp}</timestamp>
+				<timestamp>${maven.build.timestamp} (stable)</timestamp>
 			</properties>
 		</profile>
 


### PR DESCRIPTION
The current JCT version ist displayed in title of the JCT and in the error log. This helps if screenshots or error logs are used as bug reports.
<img width="475" alt="Title with version" src="https://user-images.githubusercontent.com/20046726/55262521-4cce9d00-526e-11e9-9103-694431ea8be5.PNG">

The information about the version in Error log looks like this. It is only stored in the error log if there is also an error to log. It is only saved once per start.
```
!ENTRY JCT Version Information 0 0 2019-03-29 22:06:33.463
!MESSAGE Currently used JCT Version: 1.0.0 20190324 (weekly)
``` 

Resolves https://github.com/jcryptool/core/issues/107
Resolves https://github.com/jcryptool/core/issues/138

Maybe @dschadow or @simlei can review the changes. I'm not sure if it's right to provide the Maven Build Timestamp as product property. Do you know if that makes problems elsewhere in the JCT? Everything ran smoothly in my tests.