### PR TITLE
Updated copyright to 2020

### DIFF
--- a/de.flexiprovider/src/de/flexiprovider/FlexiProviderController.java
+++ b/de.flexiprovider/src/de/flexiprovider/FlexiProviderController.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/de.flexiprovider/src/de/flexiprovider/FlexiProviderPlugin.java
+++ b/de.flexiprovider/src/de/flexiprovider/FlexiProviderPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.bouncycastle/src/org/bouncycastle/BouncyCastleController.java
+++ b/org.bouncycastle/src/org/bouncycastle/BouncyCastleController.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.bouncycastle/src/org/bouncycastle/BouncyCastlePlugin.java
+++ b/org.bouncycastle/src/org/bouncycastle/BouncyCastlePlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.actions.core/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.actions.core/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.core/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.actions.core/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.core/src/org/jcryptool/actions/core/ActionsCorePlugin.java
+++ b/org.jcryptool.actions.core/src/org/jcryptool/actions/core/ActionsCorePlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.core/src/org/jcryptool/actions/core/registry/ActionCascadeService.java
+++ b/org.jcryptool.actions.core/src/org/jcryptool/actions/core/registry/ActionCascadeService.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.core/src/org/jcryptool/actions/core/types/ActionCascade.java
+++ b/org.jcryptool.actions.core/src/org/jcryptool/actions/core/types/ActionCascade.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.core/src/org/jcryptool/actions/core/types/ActionItem.java
+++ b/org.jcryptool.actions.core/src/org/jcryptool/actions/core/types/ActionItem.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.core/src/org/jcryptool/actions/core/utils/Constants.java
+++ b/org.jcryptool.actions.core/src/org/jcryptool/actions/core/utils/Constants.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.core/src/org/jcryptool/actions/core/utils/ImportUtils.java
+++ b/org.jcryptool.actions.core/src/org/jcryptool/actions/core/utils/ImportUtils.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.ui/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.actions.ui/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.ui/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.actions.ui/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/ActionsUIPlugin.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/ActionsUIPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/ExportHandler.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/ExportHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/ImportActionCascadeHandler.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/ImportActionCascadeHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/ImportHandler.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/ImportHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/ImportSampleHandler.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/ImportSampleHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/Messages.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/MoveDownHandler.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/MoveDownHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/MoveUpHandler.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/MoveUpHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/NewCascadeHandler.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/NewCascadeHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/RecordHandler.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/RecordHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/RemoveSelectedHandler.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/RemoveSelectedHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/StartHandler.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/handler/StartHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool team and contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/preferences/GeneralPage.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/preferences/GeneralPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/preferences/Messages.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/preferences/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/preferences/PreferenceConstants.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/preferences/PreferenceConstants.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/preferences/PreferenceInitializer.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/preferences/PreferenceInitializer.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/propertytester/RecordPropertyTester.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/propertytester/RecordPropertyTester.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/utils/Constants.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/utils/Constants.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/utils/Messages.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/utils/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/views/ActionView.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/views/ActionView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/views/Messages.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/views/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/views/provider/ActionLabelProvider.java
+++ b/org.jcryptool.actions.ui/src/org/jcryptool/actions/ui/views/provider/ActionLabelProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.commands.core/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.commands.core/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.core/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.commands.core/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.core/src/org/jcryptool/commands/core/Command.java
+++ b/org.jcryptool.commands.core/src/org/jcryptool/commands/core/Command.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.commands.core/src/org/jcryptool/commands/core/CommandFactory.java
+++ b/org.jcryptool.commands.core/src/org/jcryptool/commands/core/CommandFactory.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.core/src/org/jcryptool/commands/core/CommandsCorePlugin.java
+++ b/org.jcryptool.commands.core/src/org/jcryptool/commands/core/CommandsCorePlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.core/src/org/jcryptool/commands/core/ExtendedHelpCommand.java
+++ b/org.jcryptool.commands.core/src/org/jcryptool/commands/core/ExtendedHelpCommand.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.commands.core/src/org/jcryptool/commands/core/HELP_Command.java
+++ b/org.jcryptool.commands.core/src/org/jcryptool/commands/core/HELP_Command.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.core/src/org/jcryptool/commands/core/HelpCommand.java
+++ b/org.jcryptool.commands.core/src/org/jcryptool/commands/core/HelpCommand.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.core/src/org/jcryptool/commands/core/Messages.java
+++ b/org.jcryptool.commands.core/src/org/jcryptool/commands/core/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.commands.core/src/org/jcryptool/commands/core/ProxiedCommand.java
+++ b/org.jcryptool.commands.core/src/org/jcryptool/commands/core/ProxiedCommand.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.core/src/org/jcryptool/commands/core/ProxiedExtendedCommand.java
+++ b/org.jcryptool.commands.core/src/org/jcryptool/commands/core/ProxiedExtendedCommand.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.core/src/org/jcryptool/commands/core/api/AbstractCommand.java
+++ b/org.jcryptool.commands.core/src/org/jcryptool/commands/core/api/AbstractCommand.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.core/src/org/jcryptool/commands/core/api/IllegalCommandException.java
+++ b/org.jcryptool.commands.core/src/org/jcryptool/commands/core/api/IllegalCommandException.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.commands.core/src/org/jcryptool/commands/core/api/Messages.java
+++ b/org.jcryptool.commands.core/src/org/jcryptool/commands/core/api/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.commands.core/src/org/jcryptool/commands/core/api/OptionsBuilder.java
+++ b/org.jcryptool.commands.core/src/org/jcryptool/commands/core/api/OptionsBuilder.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.commands.core/src/org/jcryptool/commands/core/evaluator/CommandEvaluator.java
+++ b/org.jcryptool.commands.core/src/org/jcryptool/commands/core/evaluator/CommandEvaluator.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.core/src/org/jcryptool/commands/core/evaluator/Messages.java
+++ b/org.jcryptool.commands.core/src/org/jcryptool/commands/core/evaluator/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.commands.ui/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.commands.ui/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.ui/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.commands.ui/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/CommandsUIPlugin.java
+++ b/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/CommandsUIPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/commands/Messages.java
+++ b/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/commands/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/commands/ShowConsoleView.java
+++ b/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/commands/ShowConsoleView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/eclipseconsole/CommandsUiStartup.java
+++ b/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/eclipseconsole/CommandsUiStartup.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/eclipseconsole/Messages.java
+++ b/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/eclipseconsole/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/eclipseconsole/console/IOConsoleInputStreamWrapper.java
+++ b/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/eclipseconsole/console/IOConsoleInputStreamWrapper.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/eclipseconsole/console/IOConsolePromptShell.java
+++ b/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/eclipseconsole/console/IOConsolePromptShell.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/eclipseconsole/console/IOConsoleShell.java
+++ b/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/eclipseconsole/console/IOConsoleShell.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/eclipseconsole/console/IOConsoleStaticPromptShell.java
+++ b/org.jcryptool.commands.ui/src/org/jcryptool/commands/ui/eclipseconsole/console/IOConsoleStaticPromptShell.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/CryptosystemPlugin.java
+++ b/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/CryptosystemPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/Alphabet.java
+++ b/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/Alphabet.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/Cryptosystem.java
+++ b/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/Cryptosystem.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/Key.java
+++ b/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/Key.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/exception/ElementNotInAlphabetException.java
+++ b/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/exception/ElementNotInAlphabetException.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/text/CharAlphabet.java
+++ b/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/text/CharAlphabet.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/text/TextCompatibleAlphabet.java
+++ b/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/text/TextCompatibleAlphabet.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/text/TextCompatibleAlphabetWrapper.java
+++ b/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/text/TextCompatibleAlphabetWrapper.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/text/TextCompatibleCryptosystem.java
+++ b/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/text/TextCompatibleCryptosystem.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/text/TextCompatibleCryptosystemWrapper.java
+++ b/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/text/TextCompatibleCryptosystemWrapper.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/text/TextConverter.java
+++ b/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/core/text/TextConverter.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/vigenere/TextVigenere.java
+++ b/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/vigenere/TextVigenere.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/vigenere/VigenereCryptosystem.java
+++ b/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/vigenere/VigenereCryptosystem.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/vigenere/VigenereKey.java
+++ b/org.jcryptool.core.cryptosystem/src/org/jcryptool/core/cryptosystem/vigenere/VigenereKey.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.dependencies.feature/feature.xml
+++ b/org.jcryptool.core.dependencies.feature/feature.xml
@@ -12,7 +12,7 @@ dependency plug-ins required to run JCrypTool.
    </description>
 
    <copyright url="https://github.com/jcryptool/core">
-      Copyright (c) 2019 JCrypTool team and contributors
+      Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License
 v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.dependencies.nl_de.feature/feature.xml
+++ b/org.jcryptool.core.dependencies.nl_de.feature/feature.xml
@@ -12,7 +12,7 @@ plug-ins required for JCrypTool.
    </description>
 
    <copyright url="https://github.com/jcryptool/core">
-      Copyright (c) 2019 JCrypTool team and contributors
+      Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License
 v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.feature/feature.xml
+++ b/org.jcryptool.core.feature/feature.xml
@@ -11,7 +11,7 @@
    </description>
 
    <copyright url="https://github.com/jcryptool/core">
-      Copyright (c) 2019 JCrypTool team and contributors
+      Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License
 v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.help/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.core.help/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core.help/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.core.help/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core.help/build.properties
+++ b/org.jcryptool.core.help/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core.logging/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.core.logging/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core.logging/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.core.logging/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core.logging/build.properties
+++ b/org.jcryptool.core.logging/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core.logging/src/org/jcryptool/core/logging/LoggingPlugin.java
+++ b/org.jcryptool.core.logging/src/org/jcryptool/core/logging/LoggingPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.logging/src/org/jcryptool/core/logging/dialogs/ExceptionDetailsErrorDialog.java
+++ b/org.jcryptool.core.logging/src/org/jcryptool/core/logging/dialogs/ExceptionDetailsErrorDialog.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.logging/src/org/jcryptool/core/logging/dialogs/JCTMessageDialog.java
+++ b/org.jcryptool.core.logging/src/org/jcryptool/core/logging/dialogs/JCTMessageDialog.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.logging/src/org/jcryptool/core/logging/dialogs/JFaceResources.java
+++ b/org.jcryptool.core.logging/src/org/jcryptool/core/logging/dialogs/JFaceResources.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.logging/src/org/jcryptool/core/logging/dialogs/Messages.java
+++ b/org.jcryptool.core.logging/src/org/jcryptool/core/logging/dialogs/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.logging/src/org/jcryptool/core/logging/preferences/pages/LoggerPage.java
+++ b/org.jcryptool.core.logging/src/org/jcryptool/core/logging/preferences/pages/LoggerPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.logging/src/org/jcryptool/core/logging/preferences/pages/Messages.java
+++ b/org.jcryptool.core.logging/src/org/jcryptool/core/logging/preferences/pages/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.core.logging/src/org/jcryptool/core/logging/utils/LogUtil.java
+++ b/org.jcryptool.core.logging/src/org/jcryptool/core/logging/utils/LogUtil.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.nl/build.properties
+++ b/org.jcryptool.core.nl/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.core.operations/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.core.operations/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/build.properties
+++ b/org.jcryptool.core.operations/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/AbstractOperationsManager.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/AbstractOperationsManager.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/CommandInfo.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/CommandInfo.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/IOperationsConstants.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/IOperationsConstants.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/OperationsPlugin.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/OperationsPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/AbstractAlgorithm.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/AbstractAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/AbstractAlgorithmHandler.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/AbstractAlgorithmHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/AlgorithmDescriptor.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/AlgorithmDescriptor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/AlgorithmRegistry.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/AlgorithmRegistry.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/IAlgorithmDescriptor.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/IAlgorithmDescriptor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/Messages.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/ShadowAlgorithmHandler.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/ShadowAlgorithmHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/classic/AbstractClassicAlgorithm.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/classic/AbstractClassicAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/classic/IClassicAlgorithmEngine.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/classic/IClassicAlgorithmEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/classic/textmodify/Messages.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/classic/textmodify/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/classic/textmodify/Transform.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/classic/textmodify/Transform.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/classic/textmodify/TransformData.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/classic/textmodify/TransformData.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/modern/AbstractModernAlgorithm.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/modern/AbstractModernAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/modern/asymmetric/AbstractAsymmetricAlgorithm.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/modern/asymmetric/AbstractAsymmetricAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/modern/hash/AbstractMessageDigestAlgorithm.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/modern/hash/AbstractMessageDigestAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/modern/hybrid/AbstractHybridAlgorithm.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/modern/hybrid/AbstractHybridAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/modern/symmetric/AbstractSymmetricAlgorithm.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/algorithm/modern/symmetric/AbstractSymmetricAlgorithm.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/AbstractAlphabet.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/AbstractAlphabet.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/AbstractAlphabetStore.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/AbstractAlphabetStore.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/AbstractAlphabetStore2.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/AbstractAlphabetStore2.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/AlphaConverter.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/AlphaConverter.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/AlphabetReference.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/AlphabetReference.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/AlphabetsManager.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/AlphabetsManager.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/AlphabetsManager2.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/AlphabetsManager2.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/GenericAlphabet.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/alphabets/GenericAlphabet.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/DataObjectConverter.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/DataObjectConverter.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/IDataObject.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/IDataObject.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/classic/ClassicDataObject.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/classic/ClassicDataObject.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/classic/ExtendedClassicDataObject.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/classic/ExtendedClassicDataObject.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/classic/IClassicDataObject.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/classic/IClassicDataObject.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/IModernDataObject.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/IModernDataObject.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/ModernDataObject.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/ModernDataObject.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/asymmetric/AsymmetricDataObject.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/asymmetric/AsymmetricDataObject.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/asymmetric/IAsymmetricDataObject.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/asymmetric/IAsymmetricDataObject.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/hybrid/HybridDataObject.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/hybrid/HybridDataObject.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/hybrid/IHybridDataObject.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/hybrid/IHybridDataObject.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/symmetric/ISymmetricDataObject.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/symmetric/ISymmetricDataObject.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/symmetric/LfsrDataObject.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/symmetric/LfsrDataObject.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/symmetric/SymmetricDataObject.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/dataobject/modern/symmetric/SymmetricDataObject.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/editors/AbstractEditorService.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/editors/AbstractEditorService.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/editors/EditorNotFoundException.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/editors/EditorNotFoundException.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/editors/EditorUtils.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/editors/EditorUtils.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/editors/EditorsManager.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/editors/EditorsManager.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/editors/JCTElementFactory.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/editors/JCTElementFactory.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/editors/Messages.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/editors/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/keys/KeyVerificator.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/keys/KeyVerificator.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/pkcs/AbstractPKCS7Factory.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/pkcs/AbstractPKCS7Factory.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/pkcs/IPKCSFactory.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/pkcs/IPKCSFactory.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/pkcs/PKCSManager.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/pkcs/PKCSManager.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/providers/AbstractProviderController.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/providers/AbstractProviderController.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/providers/ProviderDescriptor.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/providers/ProviderDescriptor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/providers/ProviderManager2.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/providers/ProviderManager2.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/providers/ProvidersManager.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/providers/ProvidersManager.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/providers/preferences/Messages.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/providers/preferences/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/providers/preferences/ProvidersPreferencesInitializer.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/providers/preferences/ProvidersPreferencesInitializer.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/providers/preferences/ProvidersPreferencesPage.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/providers/preferences/ProvidersPreferencesPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/util/ByteArrayUtils.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/util/ByteArrayUtils.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.operations/src/org/jcryptool/core/operations/util/PathEditorInput.java
+++ b/org.jcryptool.core.operations/src/org/jcryptool/core/operations/util/PathEditorInput.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.core.util/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.core.util/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/DynamicOnetimeTask.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/DynamicOnetimeTask.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/calendar/CalendarService.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/calendar/CalendarService.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/colors/ColorService.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/colors/ColorService.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/constants/IConstants.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/constants/IConstants.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/constants/Messages.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/constants/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/directories/DirectoryService.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/directories/DirectoryService.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/fonts/FontService.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/fonts/FontService.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/images/ImageService.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/images/ImageService.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/input/AbstractUIInput.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/input/AbstractUIInput.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/input/ButtonInput.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/input/ButtonInput.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/input/InputVerificationResult.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/input/InputVerificationResult.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/input/Messages.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/input/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/input/TextfieldInput.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/input/TextfieldInput.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/input/handler/UIInputResultHandler.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/input/handler/UIInputResultHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/input/handler/WidgetRelatedUIInputResultHandler.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/input/handler/WidgetRelatedUIInputResultHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/numbers/NumberService.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/numbers/NumberService.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/ui/HexTextbox.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/ui/HexTextbox.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/ui/Messages.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/ui/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/ui/PasswordPrompt.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/ui/PasswordPrompt.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/ui/SingleVanishTooltipLauncher.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/ui/SingleVanishTooltipLauncher.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/UnitsService.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/UnitsService.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.views/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.core.views/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core.views/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.core.views/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core.views/build.properties
+++ b/org.jcryptool.core.views/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/AlgorithmView.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/AlgorithmView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/ISearchable.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/ISearchable.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/Messages.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/ViewsPlugin.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/ViewsPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/content/PaletteView.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/content/PaletteView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/content/TreeView.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/content/TreeView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/content/palette/AlgorithmPaletteViewer.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/content/palette/AlgorithmPaletteViewer.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/content/palette/Messages.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/content/palette/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/content/palette/ViewProviderPaletteViewer.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/content/palette/ViewProviderPaletteViewer.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/content/structure/NameSorter.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/content/structure/NameSorter.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/content/structure/TreeObject.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/content/structure/TreeObject.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/content/structure/TreeParent.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/content/structure/TreeParent.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/content/structure/ViewContentProvider.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/content/structure/ViewContentProvider.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/content/structure/ViewLabelProvider.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/content/structure/ViewLabelProvider.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/content/tree/AlgorithmTreeViewer.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/content/tree/AlgorithmTreeViewer.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/content/tree/Messages.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/content/tree/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core.views/src/org/jcryptool/core/views/content/tree/ViewProviderTreeViewer.java
+++ b/org.jcryptool.core.views/src/org/jcryptool/core/views/content/tree/ViewProviderTreeViewer.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.core/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.core/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core/about.ini
+++ b/org.jcryptool.core/about.ini
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core/build.properties
+++ b/org.jcryptool.core/build.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.core/schema/editorButton.exsd
+++ b/org.jcryptool.core/schema/editorButton.exsd
@@ -97,7 +97,7 @@
          <meta.section type="copyright"/>
       </appInfo>
       <documentation>
-         Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+         Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
       </documentation>
    </annotation>
 

--- a/org.jcryptool.core/schema/platformLanguage.exsd
+++ b/org.jcryptool.core/schema/platformLanguage.exsd
@@ -104,7 +104,7 @@
          <meta.section type="copyright"/>
       </appInfo>
       <documentation>
-         Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+         Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
       </documentation>
    </annotation>
 

--- a/org.jcryptool.core/src/org/jcryptool/core/Application.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/Application.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core/src/org/jcryptool/core/ApplicationActionBarAdvisor.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/ApplicationActionBarAdvisor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core/src/org/jcryptool/core/ApplicationWorkbenchAdvisor.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/ApplicationWorkbenchAdvisor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core/src/org/jcryptool/core/ApplicationWorkbenchWindowAdvisor.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/ApplicationWorkbenchWindowAdvisor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core/src/org/jcryptool/core/CorePlugin.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/CorePlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core/src/org/jcryptool/core/EditorAreaDropTargetListener.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/EditorAreaDropTargetListener.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core/src/org/jcryptool/core/Messages.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core/src/org/jcryptool/core/Perspective.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/Perspective.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core/src/org/jcryptool/core/commands/FileOpener.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/commands/FileOpener.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core/src/org/jcryptool/core/commands/Messages.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/commands/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.core/src/org/jcryptool/core/commands/OpenFileHandler.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/commands/OpenFileHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.core/src/org/jcryptool/core/commands/OpenNewEmptyHexEditorCommand.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/commands/OpenNewEmptyHexEditorCommand.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core/src/org/jcryptool/core/commands/OpenNewEmptyTextEditorCommand.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/commands/OpenNewEmptyTextEditorCommand.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core/src/org/jcryptool/core/commands/OpenNewSampleHexEditorCommand.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/commands/OpenNewSampleHexEditorCommand.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core/src/org/jcryptool/core/commands/OpenNewSampleTextEditorCommand.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/commands/OpenNewSampleTextEditorCommand.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core/src/org/jcryptool/core/commands/ShowHelpContents.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/commands/ShowHelpContents.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core/src/org/jcryptool/core/commands/ShowPluginViewHandler.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/commands/ShowPluginViewHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/AlgorithmsPage.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/AlgorithmsPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/AnalysisPage.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/AnalysisPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/CryptoPage.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/CryptoPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/EditorsPage.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/EditorsPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/GamesPage.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/GamesPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/GeneralPage.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/GeneralPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/Messages.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/VisualsPage.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/preferences/pages/VisualsPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.feature/feature.xml
+++ b/org.jcryptool.crypto.feature/feature.xml
@@ -11,7 +11,7 @@
    </description>
 
    <copyright url="https://github.com/jcryptool/core">
-      Copyright (c) 2019 JCrypTool team and contributors
+      Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License
 v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/AlgorithmsManager.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/AlgorithmsManager.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/FlexiProviderAlgorithmsPlugin.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/FlexiProviderAlgorithmsPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/listeners/INewOperationListener.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/listeners/INewOperationListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/listeners/NewOperationManager.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/listeners/NewOperationManager.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/DynamicComposite.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/DynamicComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/IAlgorithmParameterInputArea.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/IAlgorithmParameterInputArea.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/IDynamicComposite.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/IDynamicComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/IInputArea.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/IInputArea.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/InputFactory.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/InputFactory.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/ByteArrayInputArea.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/ByteArrayInputArea.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/CurveParamSelectionArea.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/CurveParamSelectionArea.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/DiscreteIntInputArea.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/DiscreteIntInputArea.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/FixedModeParameterArea.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/FixedModeParameterArea.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/FlexiBigIntInputArea.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/FlexiBigIntInputArea.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/QuadraticIdealComposite.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/QuadraticIdealComposite.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/RangeIntInputArea.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/RangeIntInputArea.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/StringInputArea.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/StringInputArea.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/UnspecifiedIntInputArea.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/UnspecifiedIntInputArea.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/VariableModeParameterArea.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/dynamic/composites/VariableModeParameterArea.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/views/FlexiProviderAlgorithmsView.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/views/FlexiProviderAlgorithmsView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/views/nodes/AlgorithmNode.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/views/nodes/AlgorithmNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/views/nodes/CategoryNode.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/views/nodes/CategoryNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/views/nodes/FolderNode.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/views/nodes/FolderNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/views/providers/FlexiProviderAlgorithmsViewContentProvider.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/views/providers/FlexiProviderAlgorithmsViewContentProvider.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/views/providers/FlexiProviderAlgorithmsViewLabelProvider.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/views/providers/FlexiProviderAlgorithmsViewLabelProvider.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/views/providers/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/views/providers/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/AlgorithmIntroductionPage.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/AlgorithmIntroductionPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/AlgorithmParameterWizardPage.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/AlgorithmParameterWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/AlgorithmWizard.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/AlgorithmWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/blockcipher/BlockCipherIntroductionPage.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/blockcipher/BlockCipherIntroductionPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/blockcipher/BlockCipherWizard.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/blockcipher/BlockCipherWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/blockcipher/BlockCipherWizardDialog.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/blockcipher/BlockCipherWizardDialog.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/blockcipher/IBlockCipherWizardListener.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/blockcipher/IBlockCipherWizardListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/blockcipher/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/blockcipher/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/blockcipher/ModeParameterSpecPage.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/blockcipher/ModeParameterSpecPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/securerandom/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/securerandom/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/securerandom/SecureRandomWizard.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/securerandom/SecureRandomWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/securerandom/SecureRandomWizardPage.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/securerandom/SecureRandomWizardPage.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/signature/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/signature/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/signature/SignatureWizard.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/signature/SignatureWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/signature/SignatureWizardPage.java
+++ b/org.jcryptool.crypto.flexiprovider.algorithms/src/org/jcryptool/crypto/flexiprovider/algorithms/ui/wizards/signature/SignatureWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/FlexiProviderEngine.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/FlexiProviderEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/FlexiProviderEngineFactory.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/FlexiProviderEngineFactory.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/FlexiProviderEnginesPlugin.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/FlexiProviderEnginesPlugin.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/cipher/AsymmetricBlockCipherEngine.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/cipher/AsymmetricBlockCipherEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/cipher/AsymmetricHybridCipherEngine.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/cipher/AsymmetricHybridCipherEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/cipher/BlockCipherEngine.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/cipher/BlockCipherEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/cipher/CipherEngine.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/cipher/CipherEngine.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/cipher/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/cipher/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/listener/CheckOperationListener.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/listener/CheckOperationListener.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/listener/PerformOperationListener.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/listener/PerformOperationListener.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/mac/MacEngine.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/mac/MacEngine.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/mac/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/mac/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/messagedigest/MessageDigestEngine.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/messagedigest/MessageDigestEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/securerandom/SecureRandomEngine.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/securerandom/SecureRandomEngine.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/signature/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/signature/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/signature/SignatureEngine.java
+++ b/org.jcryptool.crypto.flexiprovider.engines/src/org/jcryptool/crypto/flexiprovider/engines/signature/SignatureEngine.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.feature/feature.xml
+++ b/org.jcryptool.crypto.flexiprovider.feature/feature.xml
@@ -11,7 +11,7 @@
    </description>
 
    <copyright url="https://github.com/jcryptool/core">
-      Copyright (c) 2019 JCrypTool team and contributors
+      Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License
 v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/IntegratorHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/IntegratorHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/IntegratorOperation.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/IntegratorOperation.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/IntegratorPlugin.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/IntegratorPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/IntegratorWizard.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/IntegratorWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/IntegratorWizardPage.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/IntegratorWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/NewKeyComposite.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/NewKeyComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/NewKeyPairComposite.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/NewKeyPairComposite.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/asymmetric/elgamal/ElGamal.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/asymmetric/elgamal/ElGamal.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/asymmetric/elgamal/ElGamalHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/asymmetric/elgamal/ElGamalHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/asymmetric/rsa/Rsa.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/asymmetric/rsa/Rsa.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/asymmetric/rsa/RsaHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/asymmetric/rsa/RsaHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/blockcipher/aes/Aes.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/blockcipher/aes/Aes.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/blockcipher/aes/AesHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/blockcipher/aes/AesHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/blockcipher/idea/Idea.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/blockcipher/idea/Idea.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/blockcipher/idea/IdeaHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/blockcipher/idea/IdeaHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/blockcipher/rc6/Rc6.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/blockcipher/rc6/Rc6.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/blockcipher/rc6/Rc6Handler.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/blockcipher/rc6/Rc6Handler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/mac/hmacmd5/HMacMd5.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/mac/hmacmd5/HMacMd5.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/mac/hmacmd5/HMacMd5Handler.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/mac/hmacmd5/HMacMd5Handler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/messagedigest/md5/Md5.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/messagedigest/md5/Md5.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/messagedigest/md5/Md5Handler.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/messagedigest/md5/Md5Handler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/messagedigest/sha/Sha.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/messagedigest/sha/Sha.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/messagedigest/sha/ShaHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/messagedigest/sha/ShaHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/prng/sha1/Sha1.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/prng/sha1/Sha1.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/prng/sha1/Sha1Handler.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/prng/sha1/Sha1Handler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/signature/dsa/Dsa.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/signature/dsa/Dsa.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/signature/dsa/DsaHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.integrator/src/org/jcryptool/crypto/flexiprovider/integrator/signature/dsa/DsaHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/FlexiProviderKeystorePlugin.java
+++ b/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/FlexiProviderKeystorePlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/ImportManager.java
+++ b/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/ImportManager.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/KeyStoreHelper.java
+++ b/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/KeyStoreHelper.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2011, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/actions/ImportKeyHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/actions/ImportKeyHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+* Copyright (c) 2008, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/actions/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/actions/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available
  * under the terms of the Eclipse Public License v1.0 which accompanies this distribution,

--- a/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/actions/NewKeyPairHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/actions/NewKeyPairHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/actions/NewSymmetricKeyHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/actions/NewSymmetricKeyHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+* Copyright (c) 2008, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/wizards/ImportWizard.java
+++ b/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/wizards/ImportWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/wizards/ImportWizardPage.java
+++ b/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/wizards/ImportWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/wizards/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/wizards/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/wizards/NewKeyPairWizard.java
+++ b/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/wizards/NewKeyPairWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/wizards/NewKeyPairWizardPage.java
+++ b/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/wizards/NewKeyPairWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/wizards/NewSymmetricKeyWizard.java
+++ b/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/wizards/NewSymmetricKeyWizard.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/wizards/NewSymmetricKeyWizardPage.java
+++ b/org.jcryptool.crypto.flexiprovider.keystore/src/org/jcryptool/crypto/flexiprovider/keystore/wizards/NewSymmetricKeyWizardPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/FlexiProviderOperationsPlugin.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/FlexiProviderOperationsPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/NewOperationListener.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/NewOperationListener.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/OperationsManager.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/OperationsManager.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/engines/CheckOperationManager.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/engines/CheckOperationManager.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/engines/ICheckOperationListener.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/engines/ICheckOperationListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/engines/IPerfomOperationListener.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/engines/IPerfomOperationListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/engines/PerformOperationManager.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/engines/PerformOperationManager.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/RemoveHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/RemoveHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/RemoveKeyHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/RemoveKeyHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/RenameHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/RenameHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/io/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/io/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/io/SelectInputFileHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/io/SelectInputFileHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/io/SelectOutputFileHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/io/SelectOutputFileHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/io/SelectSignatureHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/io/SelectSignatureHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/io/SetInputEditorHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/io/SetInputEditorHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/io/SetOutputEditorHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/io/SetOutputEditorHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/io/UndefinedOperationException.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/io/UndefinedOperationException.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/ops/DecryptHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/ops/DecryptHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/ops/EncryptHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/ops/EncryptHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/ops/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/context/ops/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/menu/ExecuteOperationHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/menu/ExecuteOperationHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/menu/ExportOperationHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/menu/ExportOperationHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/menu/ImportOperationHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/menu/ImportOperationHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2008, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2008, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/menu/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/actions/menu/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/handlers/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/handlers/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/handlers/SelectKeyHandler.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/handlers/SelectKeyHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials are made available under the
 * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/listeners/IOperationChangedListener.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/listeners/IOperationChangedListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/listeners/ISelectedOperationListener.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/listeners/ISelectedOperationListener.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/EditorDragListener.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/EditorDragListener.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/FlexiProviderOperationsView.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/FlexiProviderOperationsView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/KeyDropListener.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/KeyDropListener.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/EntryNode.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/EntryNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/algorithms/AlgorithmNode.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/algorithms/AlgorithmNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/algorithms/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/algorithms/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/io/IONode.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/io/IONode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/io/InputNode.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/io/InputNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/io/InputOutputNode.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/io/InputOutputNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/io/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/io/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/io/OutputNode.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/io/OutputNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/io/SignatureIONode.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/io/SignatureIONode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/io/SignatureNode.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/io/SignatureNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/keys/KeyNode.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/keys/KeyNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/keys/KeyPairNode.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/keys/KeyPairNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/keys/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/keys/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/keys/SecretKeyNode.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/keys/SecretKeyNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/ops/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/ops/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/ops/OperationsNode.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/nodes/ops/OperationsNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/providers/FlexiProviderOperationsViewContentProvider.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/providers/FlexiProviderOperationsViewContentProvider.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/providers/FlexiProviderOperationsViewLabelProvider.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/ui/views/providers/FlexiProviderOperationsViewLabelProvider.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/EntryElement.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/EntryElement.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/ExportRootElement.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/ExportRootElement.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/OperationsViewEntryRootElement.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/OperationsViewEntryRootElement.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/algorithms/AlgorithmDescriptorElement.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/algorithms/AlgorithmDescriptorElement.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/algorithms/BlockCipherDescriptorElement.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/algorithms/BlockCipherDescriptorElement.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/algorithms/SecureRandomDescriptorElement.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/algorithms/SecureRandomDescriptorElement.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/algorithms/paramspecs/AlgorithmParameterSpecElement.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/algorithms/paramspecs/AlgorithmParameterSpecElement.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/algorithms/paramspecs/Base64Coder.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/algorithms/paramspecs/Base64Coder.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/algorithms/paramspecs/ModeParameterSpecElement.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/algorithms/paramspecs/ModeParameterSpecElement.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/io/InputOutputElement.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/io/InputOutputElement.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/io/InputSignatureElement.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/io/InputSignatureElement.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/io/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/io/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/io/OutputElement.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/io/OutputElement.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/keys/KeyElement.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/keys/KeyElement.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/keys/Messages.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/keys/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/ops/OperationElement.java
+++ b/org.jcryptool.crypto.flexiprovider.operations/src/org/jcryptool/crypto/flexiprovider/operations/xml/ops/OperationElement.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/FlexiProviderPlugin.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/FlexiProviderPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/IFlexiProviderOperation.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/IFlexiProviderOperation.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/algorithms/AlgorithmDescriptor.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/algorithms/AlgorithmDescriptor.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/algorithms/BlockCipherDescriptor.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/algorithms/BlockCipherDescriptor.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/algorithms/SecureRandomDescriptor.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/algorithms/SecureRandomDescriptor.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/MetaAlgorithm.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/MetaAlgorithm.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/MetaKeyGenerator.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/MetaKeyGenerator.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/MetaLength.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/MetaLength.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/MetaMode.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/MetaMode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/MetaOID.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/MetaOID.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/MetaPaddingScheme.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/MetaPaddingScheme.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/interfaces/IMetaAlgorithm.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/interfaces/IMetaAlgorithm.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/interfaces/IMetaEntry.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/interfaces/IMetaEntry.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/interfaces/IMetaKeyGenerator.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/interfaces/IMetaKeyGenerator.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/interfaces/IMetaLength.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/interfaces/IMetaLength.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/interfaces/IMetaMode.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/interfaces/IMetaMode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/interfaces/IMetaOID.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/interfaces/IMetaOID.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/interfaces/IMetaPaddingScheme.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/meta/interfaces/IMetaPaddingScheme.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/reflect/MetaConstructor.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/reflect/MetaConstructor.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/reflect/MetaParameter.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/reflect/MetaParameter.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/reflect/MetaSpec.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/reflect/MetaSpec.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/reflect/interfaces/IMetaConstructor.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/reflect/interfaces/IMetaConstructor.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/reflect/interfaces/IMetaParameter.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/reflect/interfaces/IMetaParameter.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/reflect/interfaces/IMetaSpec.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/descriptors/reflect/interfaces/IMetaSpec.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/exception/FlexiProviderException.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/exception/FlexiProviderException.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/exception/InvalidAlgorithmsXMLElementException.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/exception/InvalidAlgorithmsXMLElementException.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/reflect/ClassUtil.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/reflect/ClassUtil.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/reflect/Reflector.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/reflect/Reflector.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/types/OperationType.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/types/OperationType.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/types/RegistryType.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/types/RegistryType.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/ui/nodes/ITreeNode.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/ui/nodes/ITreeNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 * 
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/ui/nodes/TreeNode.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/ui/nodes/TreeNode.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/ui/perspective/FlexiProviderPerspective.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/ui/perspective/FlexiProviderPerspective.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/xml/AlgorithmsXMLConstants.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/xml/AlgorithmsXMLConstants.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/xml/AlgorithmsXMLManager.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/xml/AlgorithmsXMLManager.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/xml/FlexiProviderRootElement.java
+++ b/org.jcryptool.crypto.flexiprovider/src/org/jcryptool/crypto/flexiprovider/xml/FlexiProviderRootElement.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.crypto.keystore/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.crypto.keystore/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/IKeyStoreConstants.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/IKeyStoreConstants.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/KeyStorePlugin.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/KeyStorePlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/backend/ImportExportManager.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/backend/ImportExportManager.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/backend/KeyStoreActionManager.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/backend/KeyStoreActionManager.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/backend/KeyStoreAlias.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/backend/KeyStoreAlias.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/backend/KeyStoreManager.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/backend/KeyStoreManager.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/backend/Messages.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/backend/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/certificates/CertificateFactory.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/certificates/CertificateFactory.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/commands/ShowPropertiesHandler.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/commands/ShowPropertiesHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/ImportDescriptor.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/ImportDescriptor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/NewEntryDescriptor.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/NewEntryDescriptor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/NewKeyPairDescriptor.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/NewKeyPairDescriptor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/NewSecretKeyDescriptor.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/NewSecretKeyDescriptor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/interfaces/IContactDescriptor.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/interfaces/IContactDescriptor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/interfaces/IImportDescriptor.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/interfaces/IImportDescriptor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/interfaces/IImportWizard.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/interfaces/IImportWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/interfaces/INewEntryDescriptor.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/interfaces/INewEntryDescriptor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/interfaces/INewKeyPairDescriptor.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/interfaces/INewKeyPairDescriptor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/interfaces/INewKeyWizard.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/interfaces/INewKeyWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/interfaces/INewSecretKeyDescriptor.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/descriptors/interfaces/INewSecretKeyDescriptor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/keys/IKeyStoreAlias.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/keys/IKeyStoreAlias.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/keys/KeyType.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/keys/KeyType.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/KeystoreViewer.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/KeystoreViewer.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2013, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/KeystoreWidget.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/KeystoreWidget.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/AbstractImportKeyStoreEntryHandler.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/AbstractImportKeyStoreEntryHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/AbstractKeyStoreHandler.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/AbstractKeyStoreHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/AbstractNewKeyStoreEntryHandler.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/AbstractNewKeyStoreEntryHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/IKeyStoreActionDescriptor.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/IKeyStoreActionDescriptor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/KeyStoreActionDescriptor.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/KeyStoreActionDescriptor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/KeyStoreBackupHandler.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/KeyStoreBackupHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/Messages.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/ShadowKeyStoreHandler.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/ShadowKeyStoreHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/contacts/DeleteContactHandler.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/contacts/DeleteContactHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/contacts/NewContactHandler.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/contacts/NewContactHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/del/DeleteCertificateHandler.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/del/DeleteCertificateHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2013, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/del/DeleteKeyPairHandler.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/del/DeleteKeyPairHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2013, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/del/DeleteSecretKeyHandler.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/del/DeleteSecretKeyHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2013, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/del/Messages.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/del/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/ex/ExportCertificateHandler.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/ex/ExportCertificateHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2013, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/ex/ExportKeyPairHandler.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/ex/ExportKeyPairHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2013, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/ex/ExportSecretKeyHandler.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/ex/ExportSecretKeyHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2013, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2013, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/ex/Messages.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/actions/ex/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/CommonPropertyDialog.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/CommonPropertyDialog.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/Messages.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/SelectKeyDialog.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/SelectKeyDialog.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/ShowCertificateDialog.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/ShowCertificateDialog.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/ShowSecretKeyDialog.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/ShowSecretKeyDialog.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/TableEntry.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/TableEntry.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/AbstractKeyNodeContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/AbstractKeyNodeContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/CertificateContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/CertificateContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/CommonContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/CommonContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/ContentProviderFactory.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/ContentProviderFactory.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/Messages.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /**************************************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/CMSSPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/CMSSPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/CMSSPublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/CMSSPublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/DSAPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/DSAPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/DSAPublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/DSAPublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/ECPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/ECPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/ECPublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/ECPublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/ElGamalPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/ElGamalPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/ElGamalPublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/ElGamalPublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/GMSSPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/GMSSPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/GMSSPublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/GMSSPublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/IQDSAPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/IQDSAPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/IQDSAPublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/IQDSAPublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/IQGQPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/IQGQPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/IQGQPublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/IQGQPublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/IQRDSAPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/IQRDSAPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/IQRDSAPublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/IQRDSAPublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/LMOTSPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/LMOTSPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/LMOTSPublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/LMOTSPublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/McElieceCCA2PrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/McElieceCCA2PrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/McElieceCCA2PublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/McElieceCCA2PublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/McEliecePrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/McEliecePrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/McEliecePublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/McEliecePublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/MeRSAPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/MeRSAPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/MerkleOTSPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/MerkleOTSPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/MerkleOTSPublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/MerkleOTSPublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/MpRSAPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/MpRSAPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/NiederreiterPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/NiederreiterPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/NiederreiterPublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/NiederreiterPublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/PFlashPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/PFlashPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/PFlashPublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/PFlashPublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/RSAPublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/RSAPublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/RainbowPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/RainbowPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/RainbowPublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/RainbowPublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/SSVElGamalPrivateKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/SSVElGamalPrivateKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/SSVElGamalPublicKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/keypair/SSVElGamalPublicKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/secretkey/ECSecretKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/secretkey/ECSecretKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/secretkey/PBESecretKeyContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/dialogs/contentproviders/secretkey/PBESecretKeyContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/KeyDragListener.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/KeyDragListener.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/KeystoreView.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/KeystoreView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/interfaces/IChangeKeyStoreListener.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/interfaces/IChangeKeyStoreListener.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/interfaces/IKeyStoreListener.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/interfaces/IKeyStoreListener.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/interfaces/ISelectedNodeListener.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/interfaces/ISelectedNodeListener.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/interfaces/IViewKeyInformation.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/interfaces/IViewKeyInformation.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/Contact.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/Contact.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/ContactDescriptorNode.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/ContactDescriptorNode.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/ContactManager.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/ContactManager.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/ContactStore.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/ContactStore.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/ITreeNode.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/ITreeNode.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/Messages.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/NodeType.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/NodeType.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/TreeNode.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/TreeNode.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/containers/AbstractContainerNode.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/containers/AbstractContainerNode.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/containers/CertificateContainerNode.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/containers/CertificateContainerNode.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/containers/IKeyPairContainerNode.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/containers/IKeyPairContainerNode.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/containers/KeyPairContainerNode.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/containers/KeyPairContainerNode.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/containers/Messages.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/containers/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/containers/SecretKeyContainerNode.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/containers/SecretKeyContainerNode.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/keys/AbstractKeyNode.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/keys/AbstractKeyNode.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/keys/CertificateNode.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/keys/CertificateNode.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/keys/KeyPairNode.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/keys/KeyPairNode.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/keys/Messages.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/keys/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/keys/PrivateKeyNode.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/keys/PrivateKeyNode.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/keys/SecretKeyNode.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/nodes/keys/SecretKeyNode.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/providers/KeyStoreViewContentProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/providers/KeyStoreViewContentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/providers/KeyStoreViewLabelProvider.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/views/providers/KeyStoreViewLabelProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/wizardpages/BackupRestorePage.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/wizardpages/BackupRestorePage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/wizardpages/Messages.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/wizardpages/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/wizards/BackupRestoreWizard.java
+++ b/org.jcryptool.crypto.keystore/src/org/jcryptool/crypto/keystore/ui/wizards/BackupRestoreWizard.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/HexEditorConstants.java
+++ b/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/HexEditorConstants.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/Messages.java
+++ b/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/commands/Messages.java
+++ b/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/commands/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/commands/NewEmptyFile.java
+++ b/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/commands/NewEmptyFile.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/commands/NewFile.java
+++ b/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/commands/NewFile.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2012, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/commands/OpenEditorHandler.java
+++ b/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/commands/OpenEditorHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/commands/OpenInTextEditor.java
+++ b/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/commands/OpenInTextEditor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/service/HexEditorService.java
+++ b/org.jcryptool.editor.hex/src/org/jcryptool/editor/hex/service/HexEditorService.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2012, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.editor.text/src/org/jcryptool/editor/text/JCTTextEditorPlugin.java
+++ b/org.jcryptool.editor.text/src/org/jcryptool/editor/text/JCTTextEditorPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.editor.text/src/org/jcryptool/editor/text/commands/Messages.java
+++ b/org.jcryptool.editor.text/src/org/jcryptool/editor/text/commands/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.editor.text/src/org/jcryptool/editor/text/commands/NewEmptyTextFile.java
+++ b/org.jcryptool.editor.text/src/org/jcryptool/editor/text/commands/NewEmptyTextFile.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.editor.text/src/org/jcryptool/editor/text/commands/NewSampleTextFile.java
+++ b/org.jcryptool.editor.text/src/org/jcryptool/editor/text/commands/NewSampleTextFile.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.editor.text/src/org/jcryptool/editor/text/commands/OpenEditorHandler.java
+++ b/org.jcryptool.editor.text/src/org/jcryptool/editor/text/commands/OpenEditorHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.editor.text/src/org/jcryptool/editor/text/commands/OpenInHex.java
+++ b/org.jcryptool.editor.text/src/org/jcryptool/editor/text/commands/OpenInHex.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.editor.text/src/org/jcryptool/editor/text/editor/JCTTextEditor.java
+++ b/org.jcryptool.editor.text/src/org/jcryptool/editor/text/editor/JCTTextEditor.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2010, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2010, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.editor.text/src/org/jcryptool/editor/text/editor/Messages.java
+++ b/org.jcryptool.editor.text/src/org/jcryptool/editor/text/editor/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.editor.text/src/org/jcryptool/editor/text/editor/SimpleDocumentProvider.java
+++ b/org.jcryptool.editor.text/src/org/jcryptool/editor/text/editor/SimpleDocumentProvider.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License v1.0 which

--- a/org.jcryptool.editor.text/src/org/jcryptool/editor/text/service/JCTEditorService.java
+++ b/org.jcryptool.editor.text/src/org/jcryptool/editor/text/service/JCTEditorService.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.editor.text/src/org/jcryptool/editor/text/startup/Messages.java
+++ b/org.jcryptool.editor.text/src/org/jcryptool/editor/text/startup/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.editor.text/src/org/jcryptool/editor/text/startup/StartUp.java
+++ b/org.jcryptool.editor.text/src/org/jcryptool/editor/text/startup/StartUp.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.editors.feature/feature.xml
+++ b/org.jcryptool.editors.feature/feature.xml
@@ -11,7 +11,7 @@
    </description>
 
    <copyright url="https://github.com/jcryptool/core">
-      Copyright (c) 2019 JCrypTool team and contributors
+      Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License
 v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/OSGI-INF/l10n/bundle.properties
+++ b/org.jcryptool.fileexplorer/OSGI-INF/l10n/bundle.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/OSGI-INF/l10n/bundle_de.properties
+++ b/org.jcryptool.fileexplorer/OSGI-INF/l10n/bundle_de.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 JCrypTool Core Team - https://github.com/jcryptool
+# Copyright (c) 2011, 2020 JCrypTool Core Team - https://github.com/jcryptool
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/FileExplorerPlugin.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/FileExplorerPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/CollapseHandler.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/CollapseHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/CopyHandler.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/CopyHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/CryptoHandler.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/CryptoHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/CutHandler.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/CutHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/DeleteHandler.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/DeleteHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/HomeHandler.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/HomeHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/InvisibleToggleHandler.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/InvisibleToggleHandler.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/Messages.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/PasteHandler.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/PasteHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/RefreshHandler.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/RefreshHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/RenameHandler.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/RenameHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/ShowPropertiesHandler.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/commands/ShowPropertiesHandler.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/popup/contributions/CryptoContributionItem.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/popup/contributions/CryptoContributionItem.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2011, 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/popup/contributions/Messages.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/popup/contributions/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/preferences/GeneralPreferencePage.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/preferences/GeneralPreferencePage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/preferences/Messages.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/preferences/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/preferences/PreferenceConstants.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/preferences/PreferenceConstants.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/preferences/PreferenceInitializer.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/preferences/PreferenceInitializer.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
-* Copyright (c) 2019 JCrypTool Team and Contributors
+* Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 *
 * All rights reserved. This program and the accompanying materials
 * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/properties/Messages.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/properties/Messages.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  * 
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/properties/ResourcePropertyPage.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/properties/ResourcePropertyPage.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/tester/IFileStorePropertyTester.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/tester/IFileStorePropertyTester.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/views/FileExplorerView.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/views/FileExplorerView.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/views/FileExplorerViewerComparator.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/views/FileExplorerViewerComparator.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/views/Messages.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/views/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/views/factories/FileExplorerAdapterFactory.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/views/factories/FileExplorerAdapterFactory.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/views/factories/ImageFactory.java
+++ b/org.jcryptool.fileexplorer/src/org/jcryptool/fileexplorer/views/factories/ImageFactory.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.providers.feature/feature.xml
+++ b/org.jcryptool.providers.feature/feature.xml
@@ -11,7 +11,7 @@
    </description>
 
    <copyright url="https://github.com/jcryptool/core">
-      Copyright (c) 2019 JCrypTool team and contributors
+      Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License
 v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.views.feature/feature.xml
+++ b/org.jcryptool.views.feature/feature.xml
@@ -11,7 +11,7 @@
    </description>
 
    <copyright url="https://github.com/jcryptool/core">
-      Copyright (c) 2019 JCrypTool team and contributors
+      Copyright (c) 2011, 2020 JCrypTool Team and Contributors
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License
 v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/BrowserPlugin.java
+++ b/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/BrowserPlugin.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/command/Messages.java
+++ b/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/command/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/command/OpenWebBrowser.java
+++ b/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/command/OpenWebBrowser.java
@@ -1,6 +1,6 @@
 // -----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials are made available under the terms of the Eclipse
  * Public License v1.0 which accompanies this distribution, and is available at

--- a/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/remote/WebBrowserRemote.java
+++ b/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/remote/WebBrowserRemote.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/ui/BrowserView.java
+++ b/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/ui/BrowserView.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/ui/Controls.java
+++ b/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/ui/Controls.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/ui/Messages.java
+++ b/org.jcryptool.webbrowser/src/org/jcryptool/webbrowser/ui/Messages.java
@@ -1,6 +1,6 @@
 //-----BEGIN DISCLAIMER-----
 /*******************************************************************************
- * Copyright (c) 2019 JCrypTool Team and Contributors
+ * Copyright (c) 2011, 2020 JCrypTool Team and Contributors
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0


### PR DESCRIPTION
Changed the current year in all disclaimers from 2019 to 2020.

At the same time I have included the year of creation of the file in the copyright.

This has the advantage that the copyright is not only valid for the current year, but also for all years from the creation of the file.

The old way with only the current year looked like this:
```Copyright (c) 2020 JCrypTool Team and Contributors```

The new copyright note looks like this:
```Copyright (c) 2011, 2020 JCrypTool Team and Contributors```

