### PR TITLE
Checksums are only calculated for release builds.

### DIFF
--- a/org.jcryptool.product/pom.xml
+++ b/org.jcryptool.product/pom.xml
@@ -11,111 +11,204 @@
 	<artifactId>org.jcryptool.product</artifactId>
 	<packaging>eclipse-repository</packaging>
 
-	<build>
-		<plugins>
-				<plugin>
-					<groupId>org.eclipse.tycho</groupId>
-					<artifactId>tycho-p2-repository-plugin</artifactId>
-					<version>${tycho.version}</version>
-					<configuration>
-						<includeAllDependencies>true</includeAllDependencies>
-					</configuration>
-				</plugin>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-p2-director-plugin</artifactId>
-				<version>${tycho.version}</version>
-				<executions>
-					<execution>
-						<id>materialize-products</id>
-						<goals>
-							<goal>materialize-products</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>archive-products</id>
-						<goals>
-							<goal>archive-products</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<formats>
-						<linux>tar.gz</linux>
-						<macosx>tar.gz</macosx>
-						<win32>zip</win32>
-					</formats>
-					<products>
-						<product>
-							<id>${product.id}</id>
-							<rootFolders>
-								<linux>${product.id}</linux>
-								<macosx>${product.id}</macosx>
-								<win32>${product.id}</win32>
-							</rootFolders>
-						</product>
-					</products>
-				</configuration>
-			</plugin>
-			<plugin>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<version>1.8</version>
-				<executions>
-					<!-- rename the generated files -->
-					<execution>
-						<id>update-artifacts</id>
-						<phase>package</phase>
+	<profiles>
+		<profile>
+			<id>weekly</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+				<build>
+					<plugins>
+						<plugin>
+							<groupId>org.eclipse.tycho</groupId>
+							<artifactId>tycho-p2-repository-plugin</artifactId>
+							<version>${tycho.version}</version>
+							<configuration>
+								<includeAllDependencies>true</includeAllDependencies>
+							</configuration>
+						</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-p2-director-plugin</artifactId>
+						<version>${tycho.version}</version>
+						<executions>
+							<execution>
+								<id>materialize-products</id>
+								<goals>
+									<goal>materialize-products</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>archive-products</id>
+								<goals>
+									<goal>archive-products</goal>
+								</goals>
+							</execution>
+						</executions>
 						<configuration>
-							<target>
-								<move verbose="true"
-									todir="${project.build.directory}/products">
-									<mapper type="regexp" from="^(jcryptool-)(.*)$$"
-										to="${product.id}-${product.version}-\2" />
-
-									<fileset dir="${project.build.directory}/products">
-										<include name="*.zip" />
-										<include name="*.tar.gz" />
-									</fileset>
-								</move>
-							</target>
+							<formats>
+								<linux>tar.gz</linux>
+								<macosx>tar.gz</macosx>
+								<win32>zip</win32>
+							</formats>
+							<products>
+								<product>
+									<id>${product.id}</id>
+									<rootFolders>
+										<linux>${product.id}</linux>
+										<macosx>${product.id}</macosx>
+										<win32>${product.id}</win32>
+									</rootFolders>
+								</product>
+							</products>
 						</configuration>
-						<goals>
-							<goal>run</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>net.nicoulaj.maven.plugins</groupId>
-				<artifactId>checksum-maven-plugin</artifactId>
-				<version>1.8</version>
-				<executions>
-					<!-- calculate the hashes of the generated files -->
-					<execution>
-						<id>generate-hashes</id>
-						<phase>package</phase>
-						<goals>
-							<goal>files</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<algorithms>
-						<algorithm>MD5</algorithm>
-						<algorithm>SHA-1</algorithm>
-					</algorithms>
-					<individualFilesOutputDirectory>${project.build.directory}/products</individualFilesOutputDirectory>
-					<fileSets>
-						<fileSet>
-							<directory>${project.build.directory}/products</directory>
-							<includes>
-								<include>*.zip</include>
-								<include>*.tar.gz</include>
-							</includes>
-						</fileSet>
-					</fileSets>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+					</plugin>
+					<plugin>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<version>1.8</version>
+						<executions>
+							<!-- rename the generated files -->
+							<execution>
+								<id>update-artifacts</id>
+								<phase>package</phase>
+								<configuration>
+									<target>
+										<move verbose="true"
+											todir="${project.build.directory}/products">
+											<mapper type="regexp" from="^(jcryptool-)(.*)$$"
+												to="${product.id}-${product.version}-\2" />
+
+											<fileset dir="${project.build.directory}/products">
+												<include name="*.zip" />
+												<include name="*.tar.gz" />
+											</fileset>
+										</move>
+									</target>
+								</configuration>
+								<goals>
+									<goal>run</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		
+		<!-- Difference between weekly and release: For a weekly build no checksums are calculated -->
+		<profile>
+			<id>release</id> 
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-p2-repository-plugin</artifactId>
+						<version>${tycho.version}</version>
+						<configuration>
+							<includeAllDependencies>true</includeAllDependencies>
+						</configuration>
+					</plugin>
+					<plugin>
+						<groupId>org.eclipse.tycho</groupId>
+						<artifactId>tycho-p2-director-plugin</artifactId>
+						<version>${tycho.version}</version>
+						<executions>
+							<execution>
+								<id>materialize-products</id>
+								<goals>
+									<goal>materialize-products</goal>
+								</goals>
+							</execution>
+							<execution>
+								<id>archive-products</id>
+								<goals>
+									<goal>archive-products</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<formats>
+								<linux>tar.gz</linux>
+								<macosx>tar.gz</macosx>
+								<win32>zip</win32>
+							</formats>
+							<products>
+								<product>
+									<id>${product.id}</id>
+									<rootFolders>
+										<linux>${product.id}</linux>
+										<macosx>${product.id}</macosx>
+										<win32>${product.id}</win32>
+									</rootFolders>
+								</product>
+							</products>
+						</configuration>
+					</plugin>
+					<plugin>
+						<artifactId>maven-antrun-plugin</artifactId>
+						<version>1.8</version>
+						<executions>
+							<!-- rename the generated files -->
+							<execution>
+								<id>update-artifacts</id>
+								<phase>package</phase>
+								<configuration>
+									<target>
+										<move verbose="true"
+											todir="${project.build.directory}/products">
+											<mapper type="regexp" from="^(jcryptool-)(.*)$$"
+												to="${product.id}-${product.version}-\2" />
+
+											<fileset dir="${project.build.directory}/products">
+												<include name="*.zip" />
+												<include name="*.tar.gz" />
+											</fileset>
+										</move>
+									</target>
+								</configuration>
+								<goals>
+									<goal>run</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<groupId>net.nicoulaj.maven.plugins</groupId>
+						<artifactId>checksum-maven-plugin</artifactId>
+						<version>1.8</version>
+						<executions>
+							<!-- calculate the hashes of the generated files -->
+							<execution>
+								<id>generate-hashes</id>
+								<phase>package</phase>
+								<goals>
+									<goal>files</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<algorithms>
+								<algorithm>MD5</algorithm>
+								<algorithm>SHA-1</algorithm>
+							</algorithms>
+							<individualFilesOutputDirectory>${project.build.directory}/products</individualFilesOutputDirectory>
+							<fileSets>
+								<fileSet>
+									<directory>${project.build.directory}/products</directory>
+									<includes>
+										<include>*.zip</include>
+										<include>*.tar.gz</include>
+									</includes>
+								</fileSet>
+							</fileSets>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>  
+	
+	
+	
+	
 </project>

--- a/org.jcryptool.releng/pom.xml
+++ b/org.jcryptool.releng/pom.xml
@@ -114,6 +114,7 @@ Maven 3 and Java 8 are required for the build. See https://github.com/jcryptool/
 
 	<profiles>
 		<profile>
+		<!-- default build creates the weekly build -->
 			<id>weekly</id>
 			<activation>
 				<activeByDefault>true</activeByDefault>
@@ -123,8 +124,8 @@ Maven 3 and Java 8 are required for the build. See https://github.com/jcryptool/
 			</properties>
 		</profile>
 
+		<!-- use: mvn clean package -P release to create a release build -->
 		<profile>
-			<!-- default build creates the weekly build, to create a release use: mvn clean package -P release -->
 			<id>release</id>
 			<properties>
 				<timestamp>${maven.build.timestamp} (stable)</timestamp>


### PR DESCRIPTION
As we discussed some time ago, checksums will only be calculated for release builds, as they make it difficult for inexperienced users to choose the right download from the release page. Furthermore the checksums are not used, as the download counter https://somsubhra.com/github-release-stats/?username=jcryptool&repository=core shows.

@dshadow how is the upload of the weekly build to github handled? Can there be problems if suddenly there are no more checksums?

A small side benefit of the change: The build process for WBs is now a few seconds faster.

