### PR TITLE
Replaced html entities with human readable characters like ä, ö , ...

### DIFF
--- a/net.sourceforge.ehep/about.html
+++ b/net.sourceforge.ehep/about.html
@@ -17,7 +17,7 @@
 	<td colspan="2">
 		<p><br/><hr width="100%"/><br/>For more information please visit the plugin home page at <a href="http://ehep.sourceforge.net">http://ehep.sourceforge.net</a>.</p>
 		<p>Enjoy!</p>
-		<p><i>Marcel Palko &amp; Uwe Voigt</i></p>
+		<p><i>Marcel Palko & Uwe Voigt</i></p>
 	</td>
 </tr>
 </table>

--- a/org.jcryptool.commands.ui/nl/de/help/view.html
+++ b/org.jcryptool.commands.ui/nl/de/help/view.html
@@ -11,7 +11,7 @@
 
     <p>Die JCrypTool-<strong>Konsole</strong> ermöglicht die direkte Eingabe von kryptografischen Befehlen innerhalb JCrypTools.
     Klicken Sie zum Aufruf der Sicht auf das Konsole Icon in der Toolbar oder verwenden Sie den üblichen Weg über das Menü
-    <strong>Fenster -&gt; Sicht anzeigen</strong>.</p>
+    <strong>Fenster -> Sicht anzeigen</strong>.</p>
 
     <div class="screenshot">
 		<img src="images/view_icon.png" width="220" height="31" alt="Konsole Icon"/>

--- a/org.jcryptool.commands.ui/nl/en/help/view.html
+++ b/org.jcryptool.commands.ui/nl/en/help/view.html
@@ -10,7 +10,7 @@
     <h1>Console</h1>
 
     <p>The JCrypTool <strong>Console</strong> enables you to directly enter commands inside JCrypTool. To start the view either click
-    the console icon in the toolbar or use the usual way via the <strong>Window -&gt; Show view</strong> dialog.</p>
+    the console icon in the toolbar or use the usual way via the <strong>Window -> Show view</strong> dialog.</p>
 
     <div class="screenshot">
 		<img src="images/view_icon.png" width="220" height="31" alt="Console Icon"/>

--- a/org.jcryptool.core.dependencies.feature/epl-v10.html
+++ b/org.jcryptool.core.dependencies.feature/epl-v10.html
@@ -85,13 +85,13 @@ div.Section1
 </p>
 
 <p><span style='font-size:10.0pt'>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER
-THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE,
+THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE,
 REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE
 OF THIS AGREEMENT.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>1. DEFINITIONS</span></b> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Contribution&quot; means:</span> </p>
+<p><span style='font-size:10.0pt'>"Contribution" means:</span> </p>
 
 <p class=MsoNormal style='margin-left:.5in'><span style='font-size:10.0pt'>a)
 in the case of the initial Contributor, the initial code and documentation
@@ -113,17 +113,17 @@ Program which: (i) are separate modules of software distributed in conjunction
 with the Program under their own license agreement, and (ii) are not derivative
 works of the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Contributor&quot; means any person or
+<p><span style='font-size:10.0pt'>"Contributor" means any person or
 entity that distributes the Program.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Licensed Patents &quot; mean patent
+<p><span style='font-size:10.0pt'>"Licensed Patents " mean patent
 claims licensable by a Contributor which are necessarily infringed by the use
 or sale of its Contribution alone or when combined with the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Program&quot; means the Contributions
+<p><span style='font-size:10.0pt'>"Program" means the Contributions
 distributed in accordance with this Agreement.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Recipient&quot; means anyone who
+<p><span style='font-size:10.0pt'>"Recipient" means anyone who
 receives the Program under this Agreement, including all Contributors.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>2. GRANT OF RIGHTS</span></b> </p>
@@ -222,10 +222,10 @@ and the like. While this license is intended to facilitate the commercial use
 of the Program, the Contributor who includes the Program in a commercial
 product offering should do so in a manner which does not create potential
 liability for other Contributors. Therefore, if a Contributor includes the
-Program in a commercial product offering, such Contributor (&quot;Commercial
-Contributor&quot;) hereby agrees to defend and indemnify every other
-Contributor (&quot;Indemnified Contributor&quot;) against any losses, damages and
-costs (collectively &quot;Losses&quot;) arising from claims, lawsuits and other
+Program in a commercial product offering, such Contributor ("Commercial
+Contributor") hereby agrees to defend and indemnify every other
+Contributor ("Indemnified Contributor") against any losses, damages and
+costs (collectively "Losses") arising from claims, lawsuits and other
 legal actions brought by a third party against the Indemnified Contributor to
 the extent caused by the acts or omissions of such Commercial Contributor in
 connection with its distribution of the Program in a commercial product
@@ -250,7 +250,7 @@ Commercial Contributor must pay those damages.</span> </p>
 <p><b><span style='font-size:10.0pt'>5. NO WARRANTY</span></b> </p>
 
 <p><span style='font-size:10.0pt'>EXCEPT AS EXPRESSLY SET FORTH IN THIS
-AGREEMENT, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT
+AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING,
 WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
 MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely

--- a/org.jcryptool.core.dependencies.nl_de.feature/epl-v10.html
+++ b/org.jcryptool.core.dependencies.nl_de.feature/epl-v10.html
@@ -85,13 +85,13 @@ div.Section1
 </p>
 
 <p><span style='font-size:10.0pt'>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER
-THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE,
+THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE,
 REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE
 OF THIS AGREEMENT.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>1. DEFINITIONS</span></b> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Contribution&quot; means:</span> </p>
+<p><span style='font-size:10.0pt'>"Contribution" means:</span> </p>
 
 <p class=MsoNormal style='margin-left:.5in'><span style='font-size:10.0pt'>a)
 in the case of the initial Contributor, the initial code and documentation
@@ -113,17 +113,17 @@ Program which: (i) are separate modules of software distributed in conjunction
 with the Program under their own license agreement, and (ii) are not derivative
 works of the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Contributor&quot; means any person or
+<p><span style='font-size:10.0pt'>"Contributor" means any person or
 entity that distributes the Program.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Licensed Patents &quot; mean patent
+<p><span style='font-size:10.0pt'>"Licensed Patents " mean patent
 claims licensable by a Contributor which are necessarily infringed by the use
 or sale of its Contribution alone or when combined with the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Program&quot; means the Contributions
+<p><span style='font-size:10.0pt'>"Program" means the Contributions
 distributed in accordance with this Agreement.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Recipient&quot; means anyone who
+<p><span style='font-size:10.0pt'>"Recipient" means anyone who
 receives the Program under this Agreement, including all Contributors.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>2. GRANT OF RIGHTS</span></b> </p>
@@ -222,10 +222,10 @@ and the like. While this license is intended to facilitate the commercial use
 of the Program, the Contributor who includes the Program in a commercial
 product offering should do so in a manner which does not create potential
 liability for other Contributors. Therefore, if a Contributor includes the
-Program in a commercial product offering, such Contributor (&quot;Commercial
-Contributor&quot;) hereby agrees to defend and indemnify every other
-Contributor (&quot;Indemnified Contributor&quot;) against any losses, damages and
-costs (collectively &quot;Losses&quot;) arising from claims, lawsuits and other
+Program in a commercial product offering, such Contributor ("Commercial
+Contributor") hereby agrees to defend and indemnify every other
+Contributor ("Indemnified Contributor") against any losses, damages and
+costs (collectively "Losses") arising from claims, lawsuits and other
 legal actions brought by a third party against the Indemnified Contributor to
 the extent caused by the acts or omissions of such Commercial Contributor in
 connection with its distribution of the Program in a commercial product
@@ -250,7 +250,7 @@ Commercial Contributor must pay those damages.</span> </p>
 <p><b><span style='font-size:10.0pt'>5. NO WARRANTY</span></b> </p>
 
 <p><span style='font-size:10.0pt'>EXCEPT AS EXPRESSLY SET FORTH IN THIS
-AGREEMENT, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT
+AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING,
 WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
 MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely

--- a/org.jcryptool.core.feature/epl-v10.html
+++ b/org.jcryptool.core.feature/epl-v10.html
@@ -85,13 +85,13 @@ div.Section1
 </p>
 
 <p><span style='font-size:10.0pt'>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER
-THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE,
+THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE,
 REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE
 OF THIS AGREEMENT.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>1. DEFINITIONS</span></b> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Contribution&quot; means:</span> </p>
+<p><span style='font-size:10.0pt'>"Contribution" means:</span> </p>
 
 <p class=MsoNormal style='margin-left:.5in'><span style='font-size:10.0pt'>a)
 in the case of the initial Contributor, the initial code and documentation
@@ -113,17 +113,17 @@ Program which: (i) are separate modules of software distributed in conjunction
 with the Program under their own license agreement, and (ii) are not derivative
 works of the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Contributor&quot; means any person or
+<p><span style='font-size:10.0pt'>"Contributor" means any person or
 entity that distributes the Program.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Licensed Patents &quot; mean patent
+<p><span style='font-size:10.0pt'>"Licensed Patents " mean patent
 claims licensable by a Contributor which are necessarily infringed by the use
 or sale of its Contribution alone or when combined with the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Program&quot; means the Contributions
+<p><span style='font-size:10.0pt'>"Program" means the Contributions
 distributed in accordance with this Agreement.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Recipient&quot; means anyone who
+<p><span style='font-size:10.0pt'>"Recipient" means anyone who
 receives the Program under this Agreement, including all Contributors.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>2. GRANT OF RIGHTS</span></b> </p>
@@ -222,10 +222,10 @@ and the like. While this license is intended to facilitate the commercial use
 of the Program, the Contributor who includes the Program in a commercial
 product offering should do so in a manner which does not create potential
 liability for other Contributors. Therefore, if a Contributor includes the
-Program in a commercial product offering, such Contributor (&quot;Commercial
-Contributor&quot;) hereby agrees to defend and indemnify every other
-Contributor (&quot;Indemnified Contributor&quot;) against any losses, damages and
-costs (collectively &quot;Losses&quot;) arising from claims, lawsuits and other
+Program in a commercial product offering, such Contributor ("Commercial
+Contributor") hereby agrees to defend and indemnify every other
+Contributor ("Indemnified Contributor") against any losses, damages and
+costs (collectively "Losses") arising from claims, lawsuits and other
 legal actions brought by a third party against the Indemnified Contributor to
 the extent caused by the acts or omissions of such Commercial Contributor in
 connection with its distribution of the Program in a commercial product
@@ -250,7 +250,7 @@ Commercial Contributor must pay those damages.</span> </p>
 <p><b><span style='font-size:10.0pt'>5. NO WARRANTY</span></b> </p>
 
 <p><span style='font-size:10.0pt'>EXCEPT AS EXPRESSLY SET FORTH IN THIS
-AGREEMENT, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT
+AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING,
 WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
 MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely

--- a/org.jcryptool.core.help/nl/de/help/users/cryptology/crypto_timeline.html
+++ b/org.jcryptool.core.help/nl/de/help/users/cryptology/crypto_timeline.html
@@ -165,7 +165,7 @@
 </tr>
 <tr valign="top">
 <td>1917</td>
-<td>Der Amerikaner Gilbert S. <strong>Vernam </strong>, Mitarbeiter von AT&amp;T, entdeckt            und entwickelt das <strong>"One-time-Pad"</strong>, das einzig nachweisbar sichere            Kryptosystem.</td>
+<td>Der Amerikaner Gilbert S. <strong>Vernam </strong>, Mitarbeiter von AT&T, entdeckt            und entwickelt das <strong>"One-time-Pad"</strong>, das einzig nachweisbar sichere            Kryptosystem.</td>
 
 </tr>
 <tr valign="top">
@@ -355,7 +355,7 @@
 			<P>Weitere Übersichten zur Geschichte der Kryptologie finden sich z.B. unter den 
 			folgenden Links:</P>
 		<ul>
-		<li><a href="http://www.regenechsen.de/phpwcms/index.php?krypto_zeittafel&amp;hashID=e7813e37255d66a8af8bddf751147255">Zeittafel der Kryptologie</a></li>
+		<li><a href="http://www.regenechsen.de/phpwcms/index.php?krypto_zeittafel&hashID=e7813e37255d66a8af8bddf751147255">Zeittafel der Kryptologie</a></li>
 		<li><a href="http://www.tronland.net/cryptron/jvk.htm">Jenseits von Kahn -- Die verborgene Geschichte der Codebrecher</a></li>
 		<li><a href="http://www.xramp.com/resources/crypto-uni/">Cryptography history by XRamp</a></li>
 		<li><a href="http://cs-exhibitions.uni-klu.ac.at/index.php?id=192">The History of Cryptography (von der Virtual Exhibitions in Informatics-Seite der Universität Klagenfurth)</a></li>

--- a/org.jcryptool.core.help/nl/de/help/users/general/cheatsheets.html
+++ b/org.jcryptool.core.help/nl/de/help/users/general/cheatsheets.html
@@ -14,7 +14,7 @@
     in JCrypTool erleichtern.</p>
 
     <p>Für welchen Spickzettel Sie sich auch entscheiden, aufrufen können Sie ihn über das Menü
-    <strong>Hilfe -&gt; Spickzettel...</strong>. Im Dialog können Sie den gewünschten Spickzettel auswählen und mit OK
+    <strong>Hilfe -> Spickzettel...</strong>. Im Dialog können Sie den gewünschten Spickzettel auswählen und mit OK
     bestätigen. Es öffnet sich eine neue <a href="views.html">Sicht</a> in der die einzelnen Schritte des Spickzettels angezeigt
     werden.</p>
 

--- a/org.jcryptool.core.help/nl/de/help/users/general/editor_hex.html
+++ b/org.jcryptool.core.help/nl/de/help/users/general/editor_hex.html
@@ -18,7 +18,7 @@
   	<img src="images/hex_editor.png" width="646" height="422" alt="Hexeditor"/>
   </div>
 
-  <p>Über das Menü <strong>Bearbeiten -&gt; Öffnen mit -&gt; Texteditor</strong> können Sie die aktuell geöffnete Datei im
+  <p>Über das Menü <strong>Bearbeiten -> Öffnen mit -> Texteditor</strong> können Sie die aktuell geöffnete Datei im
   <a href="editor_text.html">Texteditor</a> öffnen. Der Hexeditor wird dabei automatisch geschlossen.</p>
 </body>
 </html>

--- a/org.jcryptool.core.help/nl/de/help/users/general/editor_text.html
+++ b/org.jcryptool.core.help/nl/de/help/users/general/editor_text.html
@@ -16,7 +16,7 @@
   	<img src="images/text_editor.png" width="404" height="437" alt="Texteditor"/>
   </div>
   
-  <p>Über das Menü <strong>Bearbeiten -&gt; Öffnen mit -&gt; Hexeditor</strong> können Sie die aktuell geöffnete Datei im 
+  <p>Über das Menü <strong>Bearbeiten -> Öffnen mit -> Hexeditor</strong> können Sie die aktuell geöffnete Datei im 
   <a href="editor_hex.html">Hexeditor</a> öffnen. Der Texteditor wird dabei automatisch geschlossen.</p>
 </body>
 </html>

--- a/org.jcryptool.core.help/nl/de/help/users/general/editors.html
+++ b/org.jcryptool.core.help/nl/de/help/users/general/editors.html
@@ -16,7 +16,7 @@
 	Operation im Texteditor aufgerufen wird das Ergebnis normalerweise auch im Texteditor angezeigt (für den Hexeditor gilt entsprechendes). Je nach
 	kryptografischer Operation kann es aber, vor allem um Darstellungsfehler auszuschließen, erforderlich sein, diese im Hexeditor zu öffnen.</p>
 	
-	<p>Nach dem Öffnen einer Datei in einem der Editoren können Sie über das <strong>Bearbeiten -&gt; Öffnen mit</strong> Menü diese im anderen Editor öffnen. Evtl.
+	<p>Nach dem Öffnen einer Datei in einem der Editoren können Sie über das <strong>Bearbeiten -> Öffnen mit</strong> Menü diese im anderen Editor öffnen. Evtl.
 	kann es dabei aber zu Darstellungsfehlern kommen.</p>
 </body>
 </html>

--- a/org.jcryptool.core.help/nl/de/help/users/general/perspectives.html
+++ b/org.jcryptool.core.help/nl/de/help/users/general/perspectives.html
@@ -19,13 +19,13 @@
 
     <p>Initial gibt JCrypTool das Layout dieser beiden Perspektiven vor. Bei Bedarf können Sie dieses Layout aber nahezu nach Belieben
     anpassen und nur von Ihnen gewünschte Sichten an den von Ihnen gewünschten Positionen anzeigen. Sollten Sie einmal eine Perspektive
-    beim Konfigurieren unbrauchbar gemacht haben, können Sie diese über das Menü <strong>Fenster -&gt; Perspektive zurücksetzen</strong>
+    beim Konfigurieren unbrauchbar gemacht haben, können Sie diese über das Menü <strong>Fenster -> Perspektive zurücksetzen</strong>
     wieder in ihren Ursprungszustand zurücksetzen lassen.</p>
 
     <p>Beim Start von JCrypTool wird Ihnen grundsätzlich die zuletzt geöffnete Perspektive angezeigt. Der Wechsel zwischen
     den beiden Perspektiven erfolgt über die beiden Icons <a href="perspective_default.html">Standard</a> und
     <a href="perspective_algorithm.html">Algorithmen</a> rechts oben oder über das Menü
-    <strong>Fenster -&gt; Perspektive öffnen</strong>. Im Menü <strong>Fenster -&gt; Perspektive anpassen</strong> können Sie
+    <strong>Fenster -> Perspektive öffnen</strong>. Im Menü <strong>Fenster -> Perspektive anpassen</strong> können Sie
     in einem Dialog auswählen, welche Elemente (d.h. Menüeinträge und Icons der Toolbar) in der aktiven Perspektive angezeigt
     werden sollen. Diese Änderungen haben nur Auswirkungen auf die gerade aktive Perspektive.</p>
 

--- a/org.jcryptool.core.help/nl/de/help/users/general/preferences.html
+++ b/org.jcryptool.core.help/nl/de/help/users/general/preferences.html
@@ -9,7 +9,7 @@
 <body>
     <h1>Benutzervorgaben</h1>
 
-    <p>Die Benutzervorgaben werden über <strong>Fenster -&gt; Benutzervorgaben</strong> aufgerufen. Aufgeteilt sind die Einstellungen
+    <p>Die Benutzervorgaben werden über <strong>Fenster -> Benutzervorgaben</strong> aufgerufen. Aufgeteilt sind die Einstellungen
     in einzelne Kategorien, wobei sich viele der in JCrypTool üblichen Kategorien (wie Algorithmen, Visualisierungen) auch in den Benutzervorgaben
     wiederfinden. Beachten Sie, dass nicht jedes Plug-in über Benutzervorgaben verfügt. Manche Einstellungen können Sie stattdessen direkt
     im Assistent oder in der Sicht des jeweiligen Plug-ins festlegen.</p>
@@ -36,7 +36,7 @@
 	den Standardwert <strong>Fehler</strong> zurücksetzen. Das Protokollieren im Info-Level produziert nicht nur sehr viele Log-Einträge (und damit eine große
 	Log-Datei), sondern verlangsamt JCrypTool durch die zusätzlichen Informationen auch.</p>
 
-	<p>Das hier generierte Protokoll finden Sie am einfachsten über die <strong>Fehlerprotokoll</strong> Sicht. Rufen Sie dazu <strong>Fenster -&gt; Sicht anzeigen</strong>
+	<p>Das hier generierte Protokoll finden Sie am einfachsten über die <strong>Fehlerprotokoll</strong> Sicht. Rufen Sie dazu <strong>Fenster -> Sicht anzeigen</strong>
 	aus. Im Dialog finden Sie das Fehlerprotokoll in der Kategorie <strong>Allgemein</strong>.</p>
 
 	<h2>Editoren</h2>

--- a/org.jcryptool.core.help/nl/de/help/users/general/view_algorithms.html
+++ b/org.jcryptool.core.help/nl/de/help/users/general/view_algorithms.html
@@ -15,7 +15,7 @@
 	abhängig davon, welche Krypto Plug-ins installiert sind.</p>
 
 	<p>Doppelklicken Sie auf einen Algorithmus auf dem Tab <strong>Algorithmen</strong>, um diesen auf den Inhalt des aktuellen Editors anzuwenden. Alternativ
-	können Sie den Algorithmus auch per Drag&amp;Drop auf den gewünschten Editor ziehen. Einträge auf den anderen drei Tabs
+	können Sie den Algorithmus auch per Drag&Drop auf den gewünschten Editor ziehen. Einträge auf den anderen drei Tabs
 	<strong>Analyse</strong>, <strong>Spiele</strong> und <strong>Visualisierungen</strong> öffnen in der
 	Regel eine eigenständige Sicht. Welche Aktion nach dem Doppelklick ausgelöst wird, hängt aber von der Implementierung des jeweiligen Krypto Plug-ins
 	ab. D.h. auch ein Eintrag auf dem Tab Analyse kann prinzipiell auch einen Assistenten starten.</p>

--- a/org.jcryptool.core.help/nl/de/help/users/general/views.html
+++ b/org.jcryptool.core.help/nl/de/help/users/general/views.html
@@ -15,10 +15,10 @@
     basierend auf dem in den <a href="preferences.html">Benutzervorgaben</a> gewählten Log-Level).</p>
 
     <p>Sichten können von Ihnen geschlossen, vergrößert oder verkleinert und auch verschoben werden. Sollten Sie eine Sicht versehentlich schließen
-    können Sie diese über das Menü <strong>Fenster -&gt; Sicht anzeigen</strong> wieder einblenden. Per Doppelklick auf den Tab der Sicht wird
+    können Sie diese über das Menü <strong>Fenster -> Sicht anzeigen</strong> wieder einblenden. Per Doppelklick auf den Tab der Sicht wird
     diese zu einer Vollbilddarstellung maximiert. Ein weiterer Doppelklick auf den Tab setzt die Sicht auf ihre ursprüngliche Größe zurück.</p>
 
-    <p>Eine Übersicht aller Sichten finden Sie im Menü <strong>Fenster -&gt; Sicht anzeigen -&gt; Andere</strong>. Der nun erscheinende Dialog enthält alle
+    <p>Eine Übersicht aller Sichten finden Sie im Menü <strong>Fenster -> Sicht anzeigen -> Andere</strong>. Der nun erscheinende Dialog enthält alle
     vorhandenen Sichten, sortiert nach Kategorie. Bereits angezeigte Sichten in dieser <a href="perspectives.html">Perspektive</a> werden
     inaktiv dargestellt und können nicht erneut eingeblendet werden.</p>
 

--- a/org.jcryptool.core.help/nl/en/help/users/cryptology/crypto_timeline.html
+++ b/org.jcryptool.core.help/nl/en/help/users/cryptology/crypto_timeline.html
@@ -161,7 +161,7 @@
 </tr>
 <tr valign="top">
 <td>1917</td>
-<td>The American, Gilbert S. <strong>Vernam</strong>, employee of AT&amp;T, discovered and developed the <strong>one-time-pad</strong>, the only provably secure crypto system.</td>
+<td>The American, Gilbert S. <strong>Vernam</strong>, employee of AT&T, discovered and developed the <strong>one-time-pad</strong>, the only provably secure crypto system.</td>
 </tr>
 <tr valign="top">
 <td>1918</td>

--- a/org.jcryptool.core.help/nl/en/help/users/general/cheatsheets.html
+++ b/org.jcryptool.core.help/nl/en/help/users/general/cheatsheets.html
@@ -13,7 +13,7 @@
     in JCrypTool, delivered by (crypto) plug-ins. However there are some basic cheat sheets available that should make your first
     steps easier.</p>
 
-    <p>No matter which cheat sheet you decide to run, you have to launch the cheat sheet dialog via <strong>Help -&gt; Cheat Sheets...</strong>.
+    <p>No matter which cheat sheet you decide to run, you have to launch the cheat sheet dialog via <strong>Help -> Cheat Sheets...</strong>.
     Select the desired cheat sheet and click on OK. A new <a href="views.html">view</a> opens, showing you the selected cheat sheet with all its
     steps.</p>
 

--- a/org.jcryptool.core.help/nl/en/help/users/general/editor_hex.html
+++ b/org.jcryptool.core.help/nl/en/help/users/general/editor_hex.html
@@ -18,7 +18,7 @@
 		<img src="images/hex_editor.png" width="646" height="422" alt="Hexeditor"/>
 	</div>
 
-	<p>Use the menu <strong>Edit -&gt; Open with -&gt; Texteditor</strong> to open the currently opened file in the <a href="editor_text.html">Texteditor</a>.
+	<p>Use the menu <strong>Edit -> Open with -> Texteditor</strong> to open the currently opened file in the <a href="editor_text.html">Texteditor</a>.
 	The Hexeditor will be closed automatically.</p>
 </body>
 </html>

--- a/org.jcryptool.core.help/nl/en/help/users/general/editor_text.html
+++ b/org.jcryptool.core.help/nl/en/help/users/general/editor_text.html
@@ -16,7 +16,7 @@
 		<img src="images/text_editor.png" width="404" height="437" alt="Texteditor"/>
 	</div>
 
-	<p>Use the menu <strong>Edit -&gt; Open with -&gt; Hexeditor</strong> to open the currently opened file in the <a href="editor_hex.html">Hexeditor</a>.
+	<p>Use the menu <strong>Edit -> Open with -> Hexeditor</strong> to open the currently opened file in the <a href="editor_hex.html">Hexeditor</a>.
 	The Texteditor will be closed automatically.</p>
 </body>
 </html>

--- a/org.jcryptool.core.help/nl/en/help/users/general/editors.html
+++ b/org.jcryptool.core.help/nl/en/help/users/general/editors.html
@@ -15,6 +15,6 @@
 	<p>The result of a cryptographic operation is normally opened in an editor of the same type (text in the text editor and hex in the hex editor). Depending
 	on the cryptographic operation it might be necessary to open the resulting file in the hex editor (in order to avoid display errors).</p>
 
-	<p>After opening a file in one of the editors it is possible to switch to the other editor using the <strong>Edit -&gt; Open with</strong> menu.</p>
+	<p>After opening a file in one of the editors it is possible to switch to the other editor using the <strong>Edit -> Open with</strong> menu.</p>
 </body>
 </html>

--- a/org.jcryptool.core.help/nl/en/help/users/general/perspectives.html
+++ b/org.jcryptool.core.help/nl/en/help/users/general/perspectives.html
@@ -18,12 +18,12 @@
   	advanced users and enables you to define every cryptographic operation in every possible detail.</p>
 
 	<p>Initially, JCrypTool has already defined the layout of both perspectives. In case of miss configuration or other problems
-	you can use the menu <strong>Window -&gt; Reset Perspective</strong> to go back to the initial configuration of that
+	you can use the menu <strong>Window -> Reset Perspective</strong> to go back to the initial configuration of that
 	perspective.</p>
 
 	<p>After launching JCrypTool, always the last active perspective is shown. Use the buttons in the upper right of the main window,
-	or the menu <strong>Window -&gt; Open Perspective</strong>, to switch between the existing perspectives. The menu
-	<strong>Window -&gt; Customize Perspective</strong> opens a dialog in which you can select the elements (menu entries and
+	or the menu <strong>Window -> Open Perspective</strong>, to switch between the existing perspectives. The menu
+	<strong>Window -> Customize Perspective</strong> opens a dialog in which you can select the elements (menu entries and
 	toolbar icons) that should be displayed in the current perspective.</p>
 
     <div class="screenshot">

--- a/org.jcryptool.core.help/nl/en/help/users/general/preferences.html
+++ b/org.jcryptool.core.help/nl/en/help/users/general/preferences.html
@@ -9,7 +9,7 @@
 <body>
     <h1>Preferences</h1>
 
-    <p>You can open the preferences via <strong>Window -&gt; Preferences</strong>. The settings are separated in categories. A lot of those categories
+    <p>You can open the preferences via <strong>Window -> Preferences</strong>. The settings are separated in categories. A lot of those categories
     do reflect the usual JCrypTool categories (like Algorithms, Visualizations). Please be aware that preferences for a plug-in are optional, no
     crypto plug-in is forced to offer preferences. Instead it is possible sometimes to define personal settings directly in the wizard or the view
     of the corresponding crypto plug-in.</p>
@@ -35,7 +35,7 @@
 	  the log level if you have a good reason to do so (e.g. to get more information for an error). Switch back to the default level as soon as possible. The info log
 	  level not only creates a lot of log entries, but slows down JCrypTool too.</p>
 
-	  <p>The generated log file is easily accessible via the <strong>Error Log</strong> view. Select <strong>Window -&gt; Show View</strong> and choose the view in the
+	  <p>The generated log file is easily accessible via the <strong>Error Log</strong> view. Select <strong>Window -> Show View</strong> and choose the view in the
 	  <strong>General</strong> category.</p>
 
 		<h2>Editors</h2>

--- a/org.jcryptool.core.help/nl/en/help/users/general/views.html
+++ b/org.jcryptool.core.help/nl/en/help/users/general/views.html
@@ -15,10 +15,10 @@
 	<a href="preferences.html">Preferences</a>).</p>
 
 	<p>You can close, resize and move any view. In case you closed a view accidentally you can reopen it using the menu
-	<strong>Window -&gt; Show View</strong>. A double click on the views tab maximizes it to full screen. Another double click on the tab
+	<strong>Window -> Show View</strong>. A double click on the views tab maximizes it to full screen. Another double click on the tab
 	minimizes the view again to its original size.</p>
 
-	<p>An overview of all views is available in the menu <strong>Window -&gt; Show View -&gt; Other</strong>. The appearing dialog contains
+	<p>An overview of all views is available in the menu <strong>Window -> Show View -> Other</strong>. The appearing dialog contains
 	all available views, sorted by category. Already visible views in this <a href="perspectives.html">Perspective</a> are shown inactive.</p>
 
     <div class="screenshot">

--- a/org.jcryptool.crypto.feature/epl-v10.html
+++ b/org.jcryptool.crypto.feature/epl-v10.html
@@ -85,13 +85,13 @@ div.Section1
 </p>
 
 <p><span style='font-size:10.0pt'>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER
-THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE,
+THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE,
 REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE
 OF THIS AGREEMENT.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>1. DEFINITIONS</span></b> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Contribution&quot; means:</span> </p>
+<p><span style='font-size:10.0pt'>"Contribution" means:</span> </p>
 
 <p class=MsoNormal style='margin-left:.5in'><span style='font-size:10.0pt'>a)
 in the case of the initial Contributor, the initial code and documentation
@@ -113,17 +113,17 @@ Program which: (i) are separate modules of software distributed in conjunction
 with the Program under their own license agreement, and (ii) are not derivative
 works of the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Contributor&quot; means any person or
+<p><span style='font-size:10.0pt'>"Contributor" means any person or
 entity that distributes the Program.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Licensed Patents &quot; mean patent
+<p><span style='font-size:10.0pt'>"Licensed Patents " mean patent
 claims licensable by a Contributor which are necessarily infringed by the use
 or sale of its Contribution alone or when combined with the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Program&quot; means the Contributions
+<p><span style='font-size:10.0pt'>"Program" means the Contributions
 distributed in accordance with this Agreement.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Recipient&quot; means anyone who
+<p><span style='font-size:10.0pt'>"Recipient" means anyone who
 receives the Program under this Agreement, including all Contributors.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>2. GRANT OF RIGHTS</span></b> </p>
@@ -222,10 +222,10 @@ and the like. While this license is intended to facilitate the commercial use
 of the Program, the Contributor who includes the Program in a commercial
 product offering should do so in a manner which does not create potential
 liability for other Contributors. Therefore, if a Contributor includes the
-Program in a commercial product offering, such Contributor (&quot;Commercial
-Contributor&quot;) hereby agrees to defend and indemnify every other
-Contributor (&quot;Indemnified Contributor&quot;) against any losses, damages and
-costs (collectively &quot;Losses&quot;) arising from claims, lawsuits and other
+Program in a commercial product offering, such Contributor ("Commercial
+Contributor") hereby agrees to defend and indemnify every other
+Contributor ("Indemnified Contributor") against any losses, damages and
+costs (collectively "Losses") arising from claims, lawsuits and other
 legal actions brought by a third party against the Indemnified Contributor to
 the extent caused by the acts or omissions of such Commercial Contributor in
 connection with its distribution of the Program in a commercial product
@@ -250,7 +250,7 @@ Commercial Contributor must pay those damages.</span> </p>
 <p><b><span style='font-size:10.0pt'>5. NO WARRANTY</span></b> </p>
 
 <p><span style='font-size:10.0pt'>EXCEPT AS EXPRESSLY SET FORTH IN THIS
-AGREEMENT, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT
+AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING,
 WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
 MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely

--- a/org.jcryptool.crypto.flexiprovider.feature/epl-v10.html
+++ b/org.jcryptool.crypto.flexiprovider.feature/epl-v10.html
@@ -85,13 +85,13 @@ div.Section1
 </p>
 
 <p><span style='font-size:10.0pt'>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER
-THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE,
+THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE,
 REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE
 OF THIS AGREEMENT.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>1. DEFINITIONS</span></b> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Contribution&quot; means:</span> </p>
+<p><span style='font-size:10.0pt'>"Contribution" means:</span> </p>
 
 <p class=MsoNormal style='margin-left:.5in'><span style='font-size:10.0pt'>a)
 in the case of the initial Contributor, the initial code and documentation
@@ -113,17 +113,17 @@ Program which: (i) are separate modules of software distributed in conjunction
 with the Program under their own license agreement, and (ii) are not derivative
 works of the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Contributor&quot; means any person or
+<p><span style='font-size:10.0pt'>"Contributor" means any person or
 entity that distributes the Program.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Licensed Patents &quot; mean patent
+<p><span style='font-size:10.0pt'>"Licensed Patents " mean patent
 claims licensable by a Contributor which are necessarily infringed by the use
 or sale of its Contribution alone or when combined with the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Program&quot; means the Contributions
+<p><span style='font-size:10.0pt'>"Program" means the Contributions
 distributed in accordance with this Agreement.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Recipient&quot; means anyone who
+<p><span style='font-size:10.0pt'>"Recipient" means anyone who
 receives the Program under this Agreement, including all Contributors.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>2. GRANT OF RIGHTS</span></b> </p>
@@ -222,10 +222,10 @@ and the like. While this license is intended to facilitate the commercial use
 of the Program, the Contributor who includes the Program in a commercial
 product offering should do so in a manner which does not create potential
 liability for other Contributors. Therefore, if a Contributor includes the
-Program in a commercial product offering, such Contributor (&quot;Commercial
-Contributor&quot;) hereby agrees to defend and indemnify every other
-Contributor (&quot;Indemnified Contributor&quot;) against any losses, damages and
-costs (collectively &quot;Losses&quot;) arising from claims, lawsuits and other
+Program in a commercial product offering, such Contributor ("Commercial
+Contributor") hereby agrees to defend and indemnify every other
+Contributor ("Indemnified Contributor") against any losses, damages and
+costs (collectively "Losses") arising from claims, lawsuits and other
 legal actions brought by a third party against the Indemnified Contributor to
 the extent caused by the acts or omissions of such Commercial Contributor in
 connection with its distribution of the Program in a commercial product
@@ -250,7 +250,7 @@ Commercial Contributor must pay those damages.</span> </p>
 <p><b><span style='font-size:10.0pt'>5. NO WARRANTY</span></b> </p>
 
 <p><span style='font-size:10.0pt'>EXCEPT AS EXPRESSLY SET FORTH IN THIS
-AGREEMENT, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT
+AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING,
 WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
 MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely

--- a/org.jcryptool.editors.feature/epl-v10.html
+++ b/org.jcryptool.editors.feature/epl-v10.html
@@ -85,13 +85,13 @@ div.Section1
 </p>
 
 <p><span style='font-size:10.0pt'>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER
-THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE,
+THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE,
 REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE
 OF THIS AGREEMENT.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>1. DEFINITIONS</span></b> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Contribution&quot; means:</span> </p>
+<p><span style='font-size:10.0pt'>"Contribution" means:</span> </p>
 
 <p class=MsoNormal style='margin-left:.5in'><span style='font-size:10.0pt'>a)
 in the case of the initial Contributor, the initial code and documentation
@@ -113,17 +113,17 @@ Program which: (i) are separate modules of software distributed in conjunction
 with the Program under their own license agreement, and (ii) are not derivative
 works of the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Contributor&quot; means any person or
+<p><span style='font-size:10.0pt'>"Contributor" means any person or
 entity that distributes the Program.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Licensed Patents &quot; mean patent
+<p><span style='font-size:10.0pt'>"Licensed Patents " mean patent
 claims licensable by a Contributor which are necessarily infringed by the use
 or sale of its Contribution alone or when combined with the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Program&quot; means the Contributions
+<p><span style='font-size:10.0pt'>"Program" means the Contributions
 distributed in accordance with this Agreement.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Recipient&quot; means anyone who
+<p><span style='font-size:10.0pt'>"Recipient" means anyone who
 receives the Program under this Agreement, including all Contributors.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>2. GRANT OF RIGHTS</span></b> </p>
@@ -222,10 +222,10 @@ and the like. While this license is intended to facilitate the commercial use
 of the Program, the Contributor who includes the Program in a commercial
 product offering should do so in a manner which does not create potential
 liability for other Contributors. Therefore, if a Contributor includes the
-Program in a commercial product offering, such Contributor (&quot;Commercial
-Contributor&quot;) hereby agrees to defend and indemnify every other
-Contributor (&quot;Indemnified Contributor&quot;) against any losses, damages and
-costs (collectively &quot;Losses&quot;) arising from claims, lawsuits and other
+Program in a commercial product offering, such Contributor ("Commercial
+Contributor") hereby agrees to defend and indemnify every other
+Contributor ("Indemnified Contributor") against any losses, damages and
+costs (collectively "Losses") arising from claims, lawsuits and other
 legal actions brought by a third party against the Indemnified Contributor to
 the extent caused by the acts or omissions of such Commercial Contributor in
 connection with its distribution of the Program in a commercial product
@@ -250,7 +250,7 @@ Commercial Contributor must pay those damages.</span> </p>
 <p><b><span style='font-size:10.0pt'>5. NO WARRANTY</span></b> </p>
 
 <p><span style='font-size:10.0pt'>EXCEPT AS EXPRESSLY SET FORTH IN THIS
-AGREEMENT, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT
+AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING,
 WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
 MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely

--- a/org.jcryptool.providers.feature/epl-v10.html
+++ b/org.jcryptool.providers.feature/epl-v10.html
@@ -85,13 +85,13 @@ div.Section1
 </p>
 
 <p><span style='font-size:10.0pt'>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER
-THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE,
+THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE,
 REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE
 OF THIS AGREEMENT.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>1. DEFINITIONS</span></b> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Contribution&quot; means:</span> </p>
+<p><span style='font-size:10.0pt'>"Contribution" means:</span> </p>
 
 <p class=MsoNormal style='margin-left:.5in'><span style='font-size:10.0pt'>a)
 in the case of the initial Contributor, the initial code and documentation
@@ -113,17 +113,17 @@ Program which: (i) are separate modules of software distributed in conjunction
 with the Program under their own license agreement, and (ii) are not derivative
 works of the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Contributor&quot; means any person or
+<p><span style='font-size:10.0pt'>"Contributor" means any person or
 entity that distributes the Program.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Licensed Patents &quot; mean patent
+<p><span style='font-size:10.0pt'>"Licensed Patents " mean patent
 claims licensable by a Contributor which are necessarily infringed by the use
 or sale of its Contribution alone or when combined with the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Program&quot; means the Contributions
+<p><span style='font-size:10.0pt'>"Program" means the Contributions
 distributed in accordance with this Agreement.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Recipient&quot; means anyone who
+<p><span style='font-size:10.0pt'>"Recipient" means anyone who
 receives the Program under this Agreement, including all Contributors.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>2. GRANT OF RIGHTS</span></b> </p>
@@ -222,10 +222,10 @@ and the like. While this license is intended to facilitate the commercial use
 of the Program, the Contributor who includes the Program in a commercial
 product offering should do so in a manner which does not create potential
 liability for other Contributors. Therefore, if a Contributor includes the
-Program in a commercial product offering, such Contributor (&quot;Commercial
-Contributor&quot;) hereby agrees to defend and indemnify every other
-Contributor (&quot;Indemnified Contributor&quot;) against any losses, damages and
-costs (collectively &quot;Losses&quot;) arising from claims, lawsuits and other
+Program in a commercial product offering, such Contributor ("Commercial
+Contributor") hereby agrees to defend and indemnify every other
+Contributor ("Indemnified Contributor") against any losses, damages and
+costs (collectively "Losses") arising from claims, lawsuits and other
 legal actions brought by a third party against the Indemnified Contributor to
 the extent caused by the acts or omissions of such Commercial Contributor in
 connection with its distribution of the Program in a commercial product
@@ -250,7 +250,7 @@ Commercial Contributor must pay those damages.</span> </p>
 <p><b><span style='font-size:10.0pt'>5. NO WARRANTY</span></b> </p>
 
 <p><span style='font-size:10.0pt'>EXCEPT AS EXPRESSLY SET FORTH IN THIS
-AGREEMENT, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT
+AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING,
 WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
 MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely

--- a/org.jcryptool.views.feature/epl-v10.html
+++ b/org.jcryptool.views.feature/epl-v10.html
@@ -85,13 +85,13 @@ div.Section1
 </p>
 
 <p><span style='font-size:10.0pt'>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER
-THE TERMS OF THIS ECLIPSE PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE,
+THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE,
 REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE
 OF THIS AGREEMENT.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>1. DEFINITIONS</span></b> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Contribution&quot; means:</span> </p>
+<p><span style='font-size:10.0pt'>"Contribution" means:</span> </p>
 
 <p class=MsoNormal style='margin-left:.5in'><span style='font-size:10.0pt'>a)
 in the case of the initial Contributor, the initial code and documentation
@@ -113,17 +113,17 @@ Program which: (i) are separate modules of software distributed in conjunction
 with the Program under their own license agreement, and (ii) are not derivative
 works of the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Contributor&quot; means any person or
+<p><span style='font-size:10.0pt'>"Contributor" means any person or
 entity that distributes the Program.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Licensed Patents &quot; mean patent
+<p><span style='font-size:10.0pt'>"Licensed Patents " mean patent
 claims licensable by a Contributor which are necessarily infringed by the use
 or sale of its Contribution alone or when combined with the Program. </span></p>
 
-<p><span style='font-size:10.0pt'>&quot;Program&quot; means the Contributions
+<p><span style='font-size:10.0pt'>"Program" means the Contributions
 distributed in accordance with this Agreement.</span> </p>
 
-<p><span style='font-size:10.0pt'>&quot;Recipient&quot; means anyone who
+<p><span style='font-size:10.0pt'>"Recipient" means anyone who
 receives the Program under this Agreement, including all Contributors.</span> </p>
 
 <p><b><span style='font-size:10.0pt'>2. GRANT OF RIGHTS</span></b> </p>
@@ -222,10 +222,10 @@ and the like. While this license is intended to facilitate the commercial use
 of the Program, the Contributor who includes the Program in a commercial
 product offering should do so in a manner which does not create potential
 liability for other Contributors. Therefore, if a Contributor includes the
-Program in a commercial product offering, such Contributor (&quot;Commercial
-Contributor&quot;) hereby agrees to defend and indemnify every other
-Contributor (&quot;Indemnified Contributor&quot;) against any losses, damages and
-costs (collectively &quot;Losses&quot;) arising from claims, lawsuits and other
+Program in a commercial product offering, such Contributor ("Commercial
+Contributor") hereby agrees to defend and indemnify every other
+Contributor ("Indemnified Contributor") against any losses, damages and
+costs (collectively "Losses") arising from claims, lawsuits and other
 legal actions brought by a third party against the Indemnified Contributor to
 the extent caused by the acts or omissions of such Commercial Contributor in
 connection with its distribution of the Program in a commercial product
@@ -250,7 +250,7 @@ Commercial Contributor must pay those damages.</span> </p>
 <p><b><span style='font-size:10.0pt'>5. NO WARRANTY</span></b> </p>
 
 <p><span style='font-size:10.0pt'>EXCEPT AS EXPRESSLY SET FORTH IN THIS
-AGREEMENT, THE PROGRAM IS PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT
+AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT
 WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING,
 WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT,
 MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely


### PR DESCRIPTION
In total
- 600 ä \&auml; 
- 326 ö \&ouml; 
- 912 ü \&uuml; 
- 72 ß \&szlig; 
- 5 & \&amp; 
- 15 < \&lt;
- 43 > \&gt;
- 586 " \&quot;

were replaced.

This improves the readability of the online help files.
