### PR TITLE
Close welcome page when new plugin is opened

### DIFF
--- a/org.jcryptool.core/META-INF/MANIFEST.MF
+++ b/org.jcryptool.core/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.equinox.p2.ui.sdk,
  org.eclipse.help,
  org.jcryptool.core.operations,
- org.jcryptool.core.util
+ org.jcryptool.core.util,
+ org.eclipse.ui.workbench
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %bundleProvider
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.jcryptool.core/src/org/jcryptool/core/commands/ShowPluginViewHandler.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/commands/ShowPluginViewHandler.java
@@ -14,6 +14,8 @@ import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.WorkbenchException;
+import org.eclipse.ui.intro.IIntroManager;
+import org.eclipse.ui.intro.IIntroPart;
 import org.jcryptool.core.CorePlugin;
 import org.jcryptool.core.logging.utils.LogUtil;
 
@@ -50,8 +52,25 @@ public class ShowPluginViewHandler extends AbstractHandler {
     @Override
 	public Object execute(ExecutionEvent event) {
         try {
-            IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+
+        	// Checks if the intro is open and closes it if a user tries
+        	// to open a new plugin
+            IIntroManager introManager = PlatformUI.getWorkbench().getIntroManager();
+            IIntroPart introPart = introManager.getIntro();
+        	if (introPart != null) {
+            	if (!introManager.isIntroStandby(introPart)) {
+            		// Wäre schöner, sieht aber hässlich aus...
+//            		introManager.setIntroStandby(introPart, true);
+            		// ..., daher Intro komplett schließen.
+            		introManager.closeIntro(introPart);
+            	}
+            }
+        	
+        	
+        	// This opens the new plugin.
+        	IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
             page.showView(viewId);
+
             
             // This was used to start all visualizations or games in a maximized window.
             // This causes Problem when using the "Restore" icons in the JCT. They don't work anymore.


### PR DESCRIPTION


Problem: If the welcome page is opened and the user tries to open a new plugin nothing visible happens. The plugin is opened behind the welcome page. Maybe frustrating for a user.


Solution: Checking if the welcome page is opened and closing it before a new plugin is opened.

![1](https://user-images.githubusercontent.com/20046726/100548598-dfa6b280-326d-11eb-804a-715420ef408e.gif)