### PR TITLE
Add Byteformatting provider

### DIFF
--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/BigMath.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/BigMath.java
@@ -1,0 +1,131 @@
+package org.jcryptool.core.util.units;
+
+
+
+import java.math.*;
+
+/**
+ * Provides some mathematical operations on {@code BigDecimal} and {@code BigInteger}.
+ * Static methods.
+ */
+public class BigMath {
+
+    public static final double LOG_2 = Math.log(2.0);
+    public static final double LOG_10 = Math.log(10.0);
+
+    // numbers greater than 10^MAX_DIGITS_10 or e^MAX_DIGITS_E are considered unsafe ('too big') for floating point operations
+    private static final int MAX_DIGITS_10 = 294;
+    private static final int MAX_DIGITS_2 = 977; // ~ MAX_DIGITS_10 * LN(10)/LN(2)
+    private static final int MAX_DIGITS_E = 677; // ~ MAX_DIGITS_10 * LN(10)
+
+    /**
+     * Computes the natural logarithm of a {@link BigInteger} 
+     * <p>
+     * Works for really big integers (practically unlimited), even when the argument 
+     * falls outside the {@code double} range
+     * <p>
+     * 
+     * 
+     * @param val Argument
+     * @return Natural logarithm, as in {@link java.lang.Math#log(double)}<br>
+     * {@code Nan} if argument is negative, {@code NEGATIVE_INFINITY} if zero.
+     */
+    public static double logBigInteger(BigInteger val) {
+        if (val.signum() < 1)
+            return val.signum() < 0 ? Double.NaN : Double.NEGATIVE_INFINITY;
+        int blex = val.bitLength() - MAX_DIGITS_2; // any value in 60..1023 works here
+        if (blex > 0)
+            val = val.shiftRight(blex);
+        double res = Math.log(val.doubleValue());
+        return blex > 0 ? res + blex * LOG_2 : res;
+    }
+
+    /**
+     * Computes the natural logarithm of a {@link BigDecimal} 
+     * <p>
+     * Works for really big (or really small) arguments, even outside the double range.
+     * 
+     * @param val Argument
+     * @return Natural logarithm, as in {@link java.lang.Math#log(double)}<br>
+     * {@code Nan} if argument is negative, {@code NEGATIVE_INFINITY} if zero.
+     */
+    public static double logBigDecimal(BigDecimal val) {
+        if (val.signum() < 1)
+            return val.signum() < 0 ? Double.NaN : Double.NEGATIVE_INFINITY;
+        int digits = val.precision() - val.scale();
+        if (digits < MAX_DIGITS_10 && digits > -MAX_DIGITS_10)
+            return Math.log(val.doubleValue());
+        else
+            return logBigInteger(val.unscaledValue()) - val.scale() * LOG_10;
+    }
+
+    /**
+     * Computes the exponential function, returning a {@link BigDecimal} (precision ~ 16).
+     * <p>
+     * Works for very big and very small exponents, even when the result 
+     * falls outside the double range.
+     *
+     * @param exponent Any finite value (infinite or {@code Nan} throws {@code IllegalArgumentException})    
+     * @return The value of {@code e} (base of the natural logarithms) raised to the given exponent, 
+     * as in {@link java.lang.Math#exp(double)}
+     */
+    public static BigDecimal expBig(double exponent) {
+        if (!Double.isFinite(exponent))
+            throw new IllegalArgumentException("Infinite not accepted: " + exponent);
+        // e^b = e^(b2+c) = e^b2 2^t with e^c = 2^t 
+        double bc = MAX_DIGITS_E;
+        if (exponent < bc && exponent > -bc)
+            return new BigDecimal(Math.exp(exponent), MathContext.DECIMAL64);
+        boolean neg = false;
+        if (exponent < 0) {
+            neg = true;
+            exponent = -exponent;
+        }
+        double b2 = bc;
+        double c = exponent - bc;
+        int t = (int) Math.ceil(c / LOG_10);
+        c = t * LOG_10;
+        b2 = exponent - c;
+        if (neg) {
+            b2 = -b2;
+            t = -t;
+        }
+        return new BigDecimal(Math.exp(b2), MathContext.DECIMAL64).movePointRight(t);
+    }
+
+    /**
+     * Same as {@link java.lang.Math#pow(double,double)} but returns a {@link BigDecimal} (precision ~ 16).
+     * <p>
+     * Works even for outputs that fall outside the {@code double} range.
+     * <br>
+     * The only limitation is that {@code b * log(a)} cannot exceed the {@code double} range. 
+     * 
+     * @param a Base. Should be non-negative 
+     * @param b Exponent. Should be finite (and non-negative if base is zero)
+     * @return Returns the value of the first argument raised to the power of the second argument.
+     */
+    public static BigDecimal powBig(double a, double b) {
+        if (!(Double.isFinite(a) && Double.isFinite(b)))
+            throw new IllegalArgumentException(
+                    Double.isFinite(b) ? "base not finite: a=" + a : "exponent not finite: b=" + b);
+        if (b == 0)
+            return BigDecimal.ONE;
+        else if (b == 1)
+            return BigDecimal.valueOf(a);
+        if (a <= 0) {
+            if (a == 0) {
+                if (b >= 0)
+                    return BigDecimal.ZERO;
+                else
+                    throw new IllegalArgumentException("0**negative = infinite b=" + b);
+            } else
+                throw new IllegalArgumentException("negative base a=" + a);
+        }
+        double x = b * Math.log(a);
+        if (Math.abs(x) < MAX_DIGITS_E)
+            return BigDecimal.valueOf(Math.pow(a, b));
+        else
+            return expBig(x);
+    }
+
+}

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/ByteFormatter.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/ByteFormatter.java
@@ -1,0 +1,14 @@
+package org.jcryptool.core.util.units;
+
+import java.math.BigInteger;
+
+public interface ByteFormatter {
+	
+	public String format(long bytes);
+	public String format(int bytes);
+	public String format(short bytes);
+	public String format(byte bytes);
+	public String format(char bytes);
+	public String format(BigInteger bytes);
+
+}

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/ByteFormatter.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/ByteFormatter.java
@@ -1,7 +1,16 @@
 package org.jcryptool.core.util.units;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 
+/**
+ * Methods for nicely formatting bytes.
+ * This interface is applied in {@link UnitsService} and a implementation is
+ * available at {@link DefaultByteFormatter}, which can be additionally parameterized
+ * with a nice builder {@link new DefaultByteFormatter.Builder().yourSettingsHere().build()}
+ * This should be enough for everyday requirements in JCrypTool.
+ * Take a look at those classes if you need more information.
+ */
 public interface ByteFormatter {
 	
 	public String format(long bytes);
@@ -9,6 +18,7 @@ public interface ByteFormatter {
 	public String format(short bytes);
 	public String format(byte bytes);
 	public String format(char bytes);
+	public String format(BigDecimal bytes);
 	public String format(BigInteger bytes);
 
 }

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/ByteFormatter.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/ByteFormatter.java
@@ -4,21 +4,28 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 /**
- * Methods for nicely formatting bytes.
- * This interface is applied in {@link UnitsService} and a implementation is
- * available at {@link DefaultByteFormatter}, which can be additionally parameterized
- * with a nice builder {@link new DefaultByteFormatter.Builder().yourSettingsHere().build()}
- * This should be enough for everyday requirements in JCrypTool.
- * Take a look at those classes if you need more information.
+ * Methods for nicely formatting bytes. This interface is applied in
+ * {@link UnitsService} and a implementation is available at
+ * {@link DefaultByteFormatter}, which can be additionally parameterized with a
+ * nice builder {@link new
+ * DefaultByteFormatter.Builder().yourSettingsHere().build()} This should be
+ * enough for everyday requirements in JCrypTool. Take a look at those classes
+ * if you need more information.
  */
 public interface ByteFormatter {
-	
-	public String format(long bytes);
-	public String format(int bytes);
-	public String format(short bytes);
-	public String format(byte bytes);
-	public String format(char bytes);
-	public String format(BigDecimal bytes);
-	public String format(BigInteger bytes);
+
+    public String format(long bytes);
+
+    public String format(int bytes);
+
+    public String format(short bytes);
+
+    public String format(byte bytes);
+
+    public String format(char bytes);
+
+    public String format(BigDecimal bytes);
+
+    public String format(BigInteger bytes);
 
 }

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/DefaultByteFormatter.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/DefaultByteFormatter.java
@@ -8,10 +8,10 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * A tool to nicely format bytes in various ways, which can be customized
- * in various flavors for (hopefully) your needs. Automatically fits 
- * JCrypTool's language (English or German) adhering stuff like 
- * thousand group separators and comma symbols.
+ * A tool to nicely format bytes in various ways, which can be customized in
+ * various flavors for (hopefully) your needs. Automatically fits JCrypTool's
+ * language (English or German) adhering stuff like thousand group separators
+ * and comma symbols.
  * 
  * Use the provided {@linkplain Builder} to adapt the settings with:
  * {@code new DefaultByteFormatter.Builder().yourSettingsHere().build()}
@@ -20,281 +20,272 @@ import java.util.List;
  * </p>
  * 
  * <p>
- * Supported functionality is 
+ * Supported functionality is
  * <ul>
- *   <li>Base10 and Base2 Units (Kilobyte 1000 vs Kibibyte 1024)</li>
- *   <li>Abbreviated units (Kilobyte vs KB)</li>
- *   <li>Locale adapted thousand separators  (1300 vs 1,300 vs 1 300)</li>
- *   <li>Threshold at which bytes are displayed with a higher prefix
- *   (e.g. set it to 15000 so that 14333 --> 14,333 Bytes and 15672 --> 15.672 Kilobytes</li>
- *   <li>Precision for printing digits (30.2 Megabyte vs 30.21674 Megabyte).</li>
- *   <li>Supports BigIntegers and BigDecimals up to Yottabyte/Yobibyte</li>
+ * <li>Base10 and Base2 Units (Kilobyte 1000 vs Kibibyte 1024)</li>
+ * <li>Abbreviated units (Kilobyte vs KB)</li>
+ * <li>Locale adapted thousand separators (1300 vs 1,300 vs 1 300)</li>
+ * <li>Threshold at which bytes are displayed with a higher prefix (e.g. set it
+ * to 15000 so that 14333 --> 14,333 Bytes and 15672 --> 15.672 Kilobytes</li>
+ * <li>Precision for printing digits (30.2 Megabyte vs 30.21674 Megabyte).</li>
+ * <li>Supports BigIntegers and BigDecimals up to Yottabyte/Yobibyte</li>
  * </ul>
  * <p>
  * 
  * @see UnitsService#registerFormatter(ByteFormatter, key)
  */
 public class DefaultByteFormatter implements ByteFormatter {
-	
-	public static class Builder {
-		
-		private BaseUnit baseUnit = BaseUnit.DEFAULT;
-		private boolean abbreviate = false;
-		private boolean useThousandSeparators = true;
-		private BigDecimal threshold = BigDecimal.valueOf(-1L);
-		private int precision = 3;
-		
-		public Builder asBase(BaseUnit baseUnit) {
-			this.baseUnit = baseUnit;
-			return this;
-		}
-		
-		public Builder abbreviateUnit(boolean abbreviate) {
-			this.abbreviate = abbreviate;
-			return this;
-		}
-		
-		public Builder scaleUpThreshold(long threshold) {
-			this.threshold = BigDecimal.valueOf(threshold);
-			return this;
-		}
-		public Builder scaleUpThreshold(BigDecimal threshold) {
-			this.threshold = threshold;
-			return this;
-		}
-		public Builder useThousandSeparators(boolean use) {
-			this.useThousandSeparators = use;
-			return this;
-		}
 
-		public Builder precision(int precision) {
-			this.precision = precision;
-			return this;
-		}
-		
-		public DefaultByteFormatter build() {
-			return new DefaultByteFormatter(
-					baseUnit, abbreviate, threshold, useThousandSeparators, precision);
-		}
-		
-	}
+    public static class Builder {
 
-	public enum BaseUnit {
-		BASE_10("base_10"),
-		BASE_2("base_2");
-		public static final BaseUnit DEFAULT=BASE_10;
-		
-		private BaseUnit(String style) { }
-	}
+        private BaseUnit baseUnit = BaseUnit.DEFAULT;
+        private boolean abbreviate = false;
+        private boolean useThousandSeparators = true;
+        private BigDecimal threshold = BigDecimal.valueOf(-1L);
+        private int precision = 3;
 
-	public enum Language {
-		EN, DE
-	}
+        public Builder asBase(BaseUnit baseUnit) {
+            this.baseUnit = baseUnit;
+            return this;
+        }
 
-	private BaseUnit baseUnit;
-	private boolean abbreviate;
-	private boolean useThousandSeparators;
-	private final BigDecimal threshold;
-	private final BigDecimal unitBig;
-	private final BigDecimal maximumPossibleValue;
-	private final BigDecimal naturalLogOfUnit;
-	private int precision;
-	private int unit;
-	private final List<String> unitMapper;
-	// Thin space to separate number from unit
-	private char unitSeperator = '\u2009';
-	
-	
-	public static final BigDecimal MAXIMUM_BASE_10_NUMBER =  new BigDecimal("1e27").subtract(BigDecimal.ONE);
-	// 2^90 - 1 is the highest number representable by a Yobibyte
-	public static final BigDecimal MAXIMUM_BASE_2_NUMBER = new BigDecimal("1237940039285380274899124223");
-	
-	private DecimalFormat formatter;
-	
-	private final String[] shortUnitsBase10 = new String[] {
-			"B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"
-	};
-	private final String[] shortUnitsBase2 = new String[] {
-			"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"
-	};
-	
-	private List<String> base10Units;
+        public Builder abbreviateUnit(boolean abbreviate) {
+            this.abbreviate = abbreviate;
+            return this;
+        }
+
+        public Builder scaleUpThreshold(long threshold) {
+            this.threshold = BigDecimal.valueOf(threshold);
+            return this;
+        }
+
+        public Builder scaleUpThreshold(BigDecimal threshold) {
+            this.threshold = threshold;
+            return this;
+        }
+
+        public Builder useThousandSeparators(boolean use) {
+            this.useThousandSeparators = use;
+            return this;
+        }
+
+        public Builder precision(int precision) {
+            this.precision = precision;
+            return this;
+        }
+
+        public DefaultByteFormatter build() {
+            return new DefaultByteFormatter(baseUnit, abbreviate, threshold, useThousandSeparators,
+                    precision);
+        }
+
+    }
+
+    public enum BaseUnit {
+        BASE_10("base_10"), BASE_2("base_2");
+
+        public static final BaseUnit DEFAULT = BASE_10;
+
+        private BaseUnit(String style) {
+        }
+    }
+
+    public enum Language {
+        EN, DE
+    }
+
+    private BaseUnit baseUnit;
+    private boolean abbreviate;
+    private boolean useThousandSeparators;
+    private final BigDecimal threshold;
+    private final BigDecimal unitBig;
+    private final BigDecimal maximumPossibleValue;
+    private final BigDecimal naturalLogOfUnit;
+    private int precision;
+    private int unit;
+    private final List<String> unitMapper;
+    // Thin space to separate number from unit
+    private char unitSeperator = '\u2009';
+
+    public static final BigDecimal MAXIMUM_BASE_10_NUMBER = new BigDecimal("1e27")
+            .subtract(BigDecimal.ONE);
+    // 2^90 - 1 is the highest number representable by a Yobibyte
+    public static final BigDecimal MAXIMUM_BASE_2_NUMBER = new BigDecimal(
+            "1237940039285380274899124223");
+
+    private DecimalFormat formatter;
+
+    private final String[] shortUnitsBase10 = new String[] { "B", "KB", "MB", "GB", "TB", "PB",
+            "EB", "ZB", "YB" };
+    private final String[] shortUnitsBase2 = new String[] { "B", "KiB", "MiB", "GiB", "TiB", "PiB",
+            "EiB", "ZiB", "YiB" };
+
+    private List<String> base10Units;
     private List<String> base2Units;
     private final BigDecimal THOUSAND = BigDecimal.valueOf(1000L);
     private final BigDecimal THOUSAND_TWENTY_FOUR = BigDecimal.valueOf(1024L);
 
-	protected DefaultByteFormatter(
-			BaseUnit baseUnit, 
-			boolean abbreviate,
-			BigDecimal scaleUpThreshold,
-			boolean useThousandSeparators,
-			int precision
-	) {
-		this.baseUnit = baseUnit;
-		this.abbreviate = abbreviate;
-		this.threshold = scaleUpThreshold.compareTo(BigDecimal.ZERO) <= 0 ? THOUSAND : scaleUpThreshold;
-		this.useThousandSeparators = useThousandSeparators;
-		this.precision = precision;
-		initializeStrings();
-		unitMapper = selectUnitMapper();
-		formatter = createNumberFormatter();
-		
-		unit = baseUnit == BaseUnit.BASE_10 ? 1000 : 1024;
-		unitBig = baseUnit == BaseUnit.BASE_10 ? THOUSAND : THOUSAND_TWENTY_FOUR;
-		maximumPossibleValue = baseUnit == BaseUnit.BASE_10 ? MAXIMUM_BASE_10_NUMBER : MAXIMUM_BASE_2_NUMBER;
-		naturalLogOfUnit = BigDecimal.valueOf(Math.log(unit));
-	}
-	
-	private DecimalFormat createNumberFormatter() {
-		var decimalFormatter = new DecimalFormat("#." + "#".repeat(precision));
-		var symbols = decimalFormatter.getDecimalFormatSymbols();
-		if (useThousandSeparators) {
-			decimalFormatter.setGroupingUsed(true);
-			decimalFormatter.setGroupingSize(3);
-			symbols.setGroupingSeparator(Messages.LocaleThousandSeparator.charAt(0));
-		} else {
-			decimalFormatter.setGroupingUsed(false);
-		}
-		symbols.setDecimalSeparator(Messages.LocaleCommaSeparator.charAt(0));
-		decimalFormatter.setDecimalFormatSymbols(symbols);
-		return decimalFormatter;
-	}
-	/**
-	 * Select one of the four possibilities of ascending units (Base 10 and Base 2 (IEC), Abbreviated and not)
-	 * @return The appropriate List as specified by the settings.
-	 */
-	private List<String> selectUnitMapper() {
-		if (abbreviate) {
-			return baseUnit == BaseUnit.BASE_10 ? Arrays.asList(shortUnitsBase10) : Arrays.asList(shortUnitsBase2);
-		} else {
-			return baseUnit == BaseUnit.BASE_10 ? base10Units : base2Units;
-		}
-	}
+    protected DefaultByteFormatter(BaseUnit baseUnit, boolean abbreviate,
+            BigDecimal scaleUpThreshold, boolean useThousandSeparators, int precision) {
+        this.baseUnit = baseUnit;
+        this.abbreviate = abbreviate;
+        this.threshold = scaleUpThreshold.compareTo(BigDecimal.ZERO) <= 0 ? THOUSAND
+                : scaleUpThreshold;
+        this.useThousandSeparators = useThousandSeparators;
+        this.precision = precision;
+        initializeStrings();
+        unitMapper = selectUnitMapper();
+        formatter = createNumberFormatter();
 
-	
-	private void initializeStrings() {
-		base10Units = new ArrayList<>();
-    	base10Units.add(Messages.unitByte);
-    	base10Units.add(Messages.unitKiloByte);
-    	base10Units.add(Messages.unitMegaByte);
-    	base10Units.add(Messages.unitGigaByte);
-    	base10Units.add(Messages.unitTeraByte);
-    	base10Units.add(Messages.unitPetaByte);
-    	base10Units.add(Messages.unitExaByte);
-    	base10Units.add(Messages.unitZettaByte);
-    	base10Units.add(Messages.unitYottaByte);
-	
-    	base2Units = new ArrayList<String>();
-    	base2Units.add(Messages.unitByte);
-    	base2Units.add(Messages.unitKibiByte);
-    	base2Units.add(Messages.unitMebiByte);
-    	base2Units.add(Messages.unitGibiByte);
-    	base2Units.add(Messages.unitTebiByte);
-    	base2Units.add(Messages.unitPebiByte);
-    	base2Units.add(Messages.unitExbiByte);
-    	base2Units.add(Messages.unitZebibyte);
-    	base2Units.add(Messages.unitYobiByte);
-	}
+        unit = baseUnit == BaseUnit.BASE_10 ? 1000 : 1024;
+        unitBig = baseUnit == BaseUnit.BASE_10 ? THOUSAND : THOUSAND_TWENTY_FOUR;
+        maximumPossibleValue = baseUnit == BaseUnit.BASE_10 ? MAXIMUM_BASE_10_NUMBER
+                : MAXIMUM_BASE_2_NUMBER;
+        naturalLogOfUnit = BigDecimal.valueOf(Math.log(unit));
+    }
 
-	/**
-	 * 
-	 * @param bytes
-	 * @return
-	 */
-	public String humanReadableByteCount(BigDecimal bytes) {
-		checkValue(bytes);
-		
-		if (bytes.compareTo(threshold) < 0) {
-			return concat(bytes, THOUSAND, unitMapper.get(0));
-		}
+    private DecimalFormat createNumberFormatter() {
+        var decimalFormatter = new DecimalFormat("#." + "#".repeat(precision));
+        var symbols = decimalFormatter.getDecimalFormatSymbols();
+        if (useThousandSeparators) {
+            decimalFormatter.setGroupingUsed(true);
+            decimalFormatter.setGroupingSize(3);
+            symbols.setGroupingSeparator(Messages.LocaleThousandSeparator.charAt(0));
+        } else {
+            decimalFormatter.setGroupingUsed(false);
+        }
+        symbols.setDecimalSeparator(Messages.LocaleCommaSeparator.charAt(0));
+        decimalFormatter.setDecimalFormatSymbols(symbols);
+        return decimalFormatter;
+    }
 
-		int exp = BigDecimal.valueOf(BigMath.logBigDecimal(bytes)).
-				divideToIntegralValue(naturalLogOfUnit).intValue();
+    /**
+     * Select one of the four possibilities of ascending units (Base 10 and Base 2
+     * (IEC), Abbreviated and not)
+     * 
+     * @return The appropriate List as specified by the settings.
+     */
+    private List<String> selectUnitMapper() {
+        if (abbreviate) {
+            return baseUnit == BaseUnit.BASE_10 ? Arrays.asList(shortUnitsBase10)
+                    : Arrays.asList(shortUnitsBase2);
+        } else {
+            return baseUnit == BaseUnit.BASE_10 ? base10Units : base2Units;
+        }
+    }
 
-		// In the edge case when threshold is set below 1000, set the exp to 1 (=1000)
-		if (bytes.compareTo(THOUSAND) < 0) {
-			exp = 1;
-		}
-		BigDecimal unitSize = unitBig.pow(exp);
-		BigDecimal convertedBytes = bytes.divide(unitSize);
-		return concat(convertedBytes, unitSize, unitMapper.get(exp));
-	}
-	
-	/**
-	 * 
-	 * @param bytes
-	 * @param unitSize
-	 * @param unit
-	 * @return
-	 */
-	private String concat(BigDecimal bytes, BigDecimal unitSize, String unit) {
-		// Append an s if not abbreviated and either bytes = 1 or exactly divided.
-		boolean isOne = bytes.compareTo(BigDecimal.ONE) == 0;
-		// Remainder is at position 2 of returned array.
-		BigDecimal remainder = bytes.divideAndRemainder(unitSize)[1];
-		boolean isOneWithUnit = unitSize.compareTo(BigDecimal.ONE) > 0 &&
-				remainder.compareTo(BigDecimal.ZERO) == 0;
-		
-		// Only append a plural 's' if is not 1 (byte = 1) or divides
-		// a unit cleanly (1000 bytes = 1 Kilobyte)
-		if (!abbreviate && !isOne && !isOneWithUnit) {
-			unit += 's';
-		}
-		return formatter.format(bytes) + unitSeperator + unit; 
-	}
-	
-	private void checkValue(BigDecimal value) {
-		if (value.abs().compareTo(maximumPossibleValue) > 0) {
-			throw new IllegalArgumentException(
-					String.format(
-							"Value too big to format: %s. The maximum allowed value is %s",
-							formatter.format(value),
-							formatter.format(maximumPossibleValue)
-					)
-			);
-		}
-	}
+    private void initializeStrings() {
+        base10Units = new ArrayList<>();
+        base10Units.add(Messages.unitByte);
+        base10Units.add(Messages.unitKiloByte);
+        base10Units.add(Messages.unitMegaByte);
+        base10Units.add(Messages.unitGigaByte);
+        base10Units.add(Messages.unitTeraByte);
+        base10Units.add(Messages.unitPetaByte);
+        base10Units.add(Messages.unitExaByte);
+        base10Units.add(Messages.unitZettaByte);
+        base10Units.add(Messages.unitYottaByte);
 
-	@Override
-	public String format(long bytes) {
-		return humanReadableByteCount(BigDecimal.valueOf(bytes));
-	}
+        base2Units = new ArrayList<String>();
+        base2Units.add(Messages.unitByte);
+        base2Units.add(Messages.unitKibiByte);
+        base2Units.add(Messages.unitMebiByte);
+        base2Units.add(Messages.unitGibiByte);
+        base2Units.add(Messages.unitTebiByte);
+        base2Units.add(Messages.unitPebiByte);
+        base2Units.add(Messages.unitExbiByte);
+        base2Units.add(Messages.unitZebibyte);
+        base2Units.add(Messages.unitYobiByte);
+    }
 
+    /**
+     * 
+     * @param bytes
+     * @return
+     */
+    public String humanReadableByteCount(BigDecimal bytes) {
+        checkValue(bytes);
 
+        if (bytes.compareTo(threshold) < 0) {
+            return concat(bytes, THOUSAND, unitMapper.get(0));
+        }
 
-	@Override
-	public String format(int bytes) {
-		return humanReadableByteCount(BigDecimal.valueOf(bytes));
-	}
+        int exp = BigDecimal.valueOf(BigMath.logBigDecimal(bytes))
+                .divideToIntegralValue(naturalLogOfUnit).intValue();
 
+        // In the edge case when threshold is set below 1000, set the exp to 1 (=1000)
+        if (bytes.compareTo(THOUSAND) < 0) {
+            exp = 1;
+        }
+        BigDecimal unitSize = unitBig.pow(exp);
+        BigDecimal convertedBytes = bytes.divide(unitSize);
+        return concat(convertedBytes, unitSize, unitMapper.get(exp));
+    }
 
-	@Override
-	public String format(short bytes) {
-		return humanReadableByteCount(BigDecimal.valueOf(bytes));
-	}
+    /**
+     * 
+     * @param bytes
+     * @param unitSize
+     * @param unit
+     * @return
+     */
+    private String concat(BigDecimal bytes, BigDecimal unitSize, String unit) {
+        // Append an s if not abbreviated and either bytes = 1 or exactly divided.
+        boolean isOne = bytes.compareTo(BigDecimal.ONE) == 0;
+        // Remainder is at position 2 of returned array.
+        BigDecimal remainder = bytes.divideAndRemainder(unitSize)[1];
+        boolean isOneWithUnit = unitSize.compareTo(BigDecimal.ONE) > 0
+                && remainder.compareTo(BigDecimal.ZERO) == 0;
 
+        // Only append a plural 's' if is not 1 (byte = 1) or divides
+        // a unit cleanly (1000 bytes = 1 Kilobyte)
+        if (!abbreviate && !isOne && !isOneWithUnit) {
+            unit += 's';
+        }
+        return formatter.format(bytes) + unitSeperator + unit;
+    }
 
-	@Override
-	public String format(byte bytes) {
-		return humanReadableByteCount(BigDecimal.valueOf(bytes));
-	}
+    private void checkValue(BigDecimal value) {
+        if (value.abs().compareTo(maximumPossibleValue) > 0) {
+            throw new IllegalArgumentException(
+                    String.format("Value too big to format: %s. The maximum allowed value is %s",
+                            formatter.format(value), formatter.format(maximumPossibleValue)));
+        }
+    }
 
+    @Override
+    public String format(long bytes) {
+        return humanReadableByteCount(BigDecimal.valueOf(bytes));
+    }
 
+    @Override
+    public String format(int bytes) {
+        return humanReadableByteCount(BigDecimal.valueOf(bytes));
+    }
 
-	@Override
-	public String format(char bytes) {
-		return humanReadableByteCount(BigDecimal.valueOf(bytes));
-	}
+    @Override
+    public String format(short bytes) {
+        return humanReadableByteCount(BigDecimal.valueOf(bytes));
+    }
 
-	@Override
-	public String format(BigDecimal bytes) {
-		return humanReadableByteCount(bytes);
-	}
-	
-	@Override
-	public String format(BigInteger bytes) {
-		return humanReadableByteCount(new BigDecimal(bytes));
-	}
+    @Override
+    public String format(byte bytes) {
+        return humanReadableByteCount(BigDecimal.valueOf(bytes));
+    }
 
+    @Override
+    public String format(char bytes) {
+        return humanReadableByteCount(BigDecimal.valueOf(bytes));
+    }
+
+    @Override
+    public String format(BigDecimal bytes) {
+        return humanReadableByteCount(bytes);
+    }
+
+    @Override
+    public String format(BigInteger bytes) {
+        return humanReadableByteCount(new BigDecimal(bytes));
+    }
 
 }

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/DefaultByteFormatter.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/DefaultByteFormatter.java
@@ -1,0 +1,233 @@
+package org.jcryptool.core.util.units;
+
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class DefaultByteFormatter implements ByteFormatter {
+	
+	public static class Builder {
+		
+		private BaseUnit baseUnit = BaseUnit.DEFAULT;
+		private Language language = Language.EN;
+		private boolean abbreviate = false;
+		private boolean useThousandSeparators = true;
+		private long threshold = -1;
+		private int precision = 3;
+		
+		public Builder asBase(BaseUnit baseUnit) {
+			this.baseUnit = baseUnit;
+			return this;
+		}
+		
+		public Builder abbreviateUnit(boolean abbreviate) {
+			this.abbreviate = abbreviate;
+			return this;
+		}
+		
+		public Builder scaleUpThreshold(long threshold) {
+			this.threshold = threshold;
+			return this;
+		}
+		public Builder useThousandSeparators(boolean use) {
+			this.useThousandSeparators = use;
+			return this;
+		}
+
+		public Builder precision(int precision) {
+			this.precision = precision;
+			return this;
+		}
+		
+		public DefaultByteFormatter build() {
+			return new DefaultByteFormatter(
+					baseUnit, abbreviate, threshold, useThousandSeparators, precision);
+		}
+		
+	}
+
+	public enum BaseUnit {
+		BASE_10("base_10"),
+		BASE_2("base_2");
+		public static final BaseUnit DEFAULT=BASE_10;
+		
+		private BaseUnit(String style) { }
+	}
+
+	public enum Language {
+		EN, DE
+	}
+
+	private BaseUnit baseUnit;
+	private boolean abbreviate;
+	private boolean useThousandSeparators;
+	private long threshold;
+	private int precision;
+	private final List<String> unitMapper;
+	private char unitSeperator = '\u2009';
+	
+	
+	private static final long MAXIMUM_BASE_10_NUMBER = (long) 1000e11 - 1;
+	private static final long MAXIMUM_BASE_2_NUMBER = ((long) Math.pow(1024, 9)) - 1;
+	
+	private DecimalFormat formatter;
+	
+	private final String[] shortUnitsBase10 = new String[] {
+			"B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"
+	};
+	private final String[] shortUnitsBase2 = new String[] {
+			"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"
+	};
+	
+	private List<String> base10Units;
+    private List<String> base2Units;
+
+	protected DefaultByteFormatter(
+			BaseUnit baseUnit, 
+			boolean abbreviate,
+			long scaleUpThreshold,
+			boolean useThousandSeparators,
+			int precision
+	) {
+		this.baseUnit = baseUnit;
+		this.abbreviate = abbreviate;
+		this.threshold = scaleUpThreshold <= 0 ? 1000 : scaleUpThreshold;
+		this.useThousandSeparators = useThousandSeparators;
+		this.precision = precision;
+		initializeStrings();
+		unitMapper = selectUnitMapper();
+		formatter = createNumberFormatter();
+	}
+	
+	private DecimalFormat createNumberFormatter() {
+		var decimalFormatter = new DecimalFormat("#." + "#".repeat(precision));
+		var symbols = decimalFormatter.getDecimalFormatSymbols();
+		if (useThousandSeparators) {
+			symbols.setGroupingSeparator(Messages.LocaleThousandSeparator.charAt(0));
+		} else {
+			decimalFormatter.setGroupingUsed(false);
+		}
+		symbols.setDecimalSeparator(Messages.LocaleCommaSeparator.charAt(0));
+		decimalFormatter.setDecimalFormatSymbols(symbols);
+		return decimalFormatter;
+	}
+	/**
+	 * Select one of the four possibilities of ascending units (Base 10 and Base 2 (IEC), Abbreviated and not)
+	 * @return The appropriate List as specified by the settings.
+	 */
+	private List<String> selectUnitMapper() {
+		if (abbreviate) {
+			return baseUnit == BaseUnit.BASE_10 ? Arrays.asList(shortUnitsBase10) : Arrays.asList(shortUnitsBase2);
+		} else {
+			return baseUnit == BaseUnit.BASE_10 ? base10Units : base2Units;
+		}
+	}
+
+	
+	private void initializeStrings() {
+		base10Units = new ArrayList<>();
+    	base10Units.add(Messages.unitByte);
+    	base10Units.add(Messages.unitKiloByte);
+    	base10Units.add(Messages.unitMegaByte);
+    	base10Units.add(Messages.unitGigaByte);
+    	base10Units.add(Messages.unitTeraByte);
+    	base10Units.add(Messages.unitPetaByte);
+    	base10Units.add(Messages.unitExaByte);
+    	base10Units.add(Messages.unitZettaByte);
+    	base10Units.add(Messages.unitYottaByte);
+	
+    	base2Units = new ArrayList<String>();
+    	base2Units.add(Messages.unitByte);
+    	base2Units.add(Messages.unitKibiByte);
+    	base2Units.add(Messages.unitMebiByte);
+    	base2Units.add(Messages.unitGibiByte);
+    	base2Units.add(Messages.unitTebiByte);
+    	base2Units.add(Messages.unitPebiByte);
+    	base2Units.add(Messages.unitExbiByte);
+    	base2Units.add(Messages.unitZebibyte);
+    	base2Units.add(Messages.unitYobiByte);
+	}
+
+	/**
+	 * 
+	 * @param bytes
+	 * @return
+	 */
+	public String humanReadableByteCount(BigInteger bytes) {
+		
+		int unit = baseUnit == BaseUnit.BASE_10 ? 1000 : 1024;
+		
+		if (bytes < threshold) {
+			return concat(bytes, 1000, unitMapper.get(0));
+		}
+
+		int exp = (int) (Math.log(bytes) / Math.log(unit));
+
+		// In the edge case when threshold is set below 1000, set the exp to 1 (=1000)
+		if (bytes < 1000) {
+			exp = 1;
+		}
+		double convertedBytes = bytes / Math.pow(unit, exp);
+		return concat(convertedBytes, (long) Math.pow(unit, exp), unitMapper.get(exp));
+	}
+	
+	/**
+	 * 
+	 * @param bytes
+	 * @param reference
+	 * @param unit
+	 * @return
+	 */
+	private String concat(double bytes, long reference, String unit) {
+		// Append an s if not abbreviated and either bytes = 1 or exactly divided.
+		boolean isOne = bytes == 1;
+		boolean isOneWithUnit = reference > 1 && bytes % reference == 0;
+		
+		if (!abbreviate && !isOne && !isOneWithUnit) {
+			unit += 's';
+		}
+		return formatter.format(bytes) + unitSeperator + unit; 
+	}
+	
+	private void checkExponent(int exponent) {
+		if (exponent >= unitMapper.size()) {
+			throw new IllegalArgumentException("");
+		}
+	}
+
+	@Override
+	public String format(long bytes) {
+		return humanReadableByteCount(bytes);
+	}
+
+
+
+	@Override
+	public String format(int bytes) {
+		return humanReadableByteCount(bytes);
+	}
+
+
+	@Override
+	public String format(short bytes) {
+		return humanReadableByteCount(bytes);
+	}
+
+
+	@Override
+	public String format(byte bytes) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+
+
+	@Override
+	public String format(char bytes) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+
+}

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/DefaultByteFormatter.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/DefaultByteFormatter.java
@@ -1,19 +1,47 @@
 package org.jcryptool.core.util.units;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+/**
+ * A tool to nicely format bytes in various ways, which can be customized
+ * in various flavors for (hopefully) your needs. Automatically fits 
+ * JCrypTool's language (English or German) adhering stuff like 
+ * thousand group separators and comma symbols.
+ * 
+ * Use the provided {@linkplain Builder} to adapt the settings with:
+ * {@code new DefaultByteFormatter.Builder().yourSettingsHere().build()}
+ * <p>
+ * Either use the class directly or register it at {@link UnitsService}.
+ * </p>
+ * 
+ * <p>
+ * Supported functionality is 
+ * <ul>
+ *   <li>Base10 and Base2 Units (Kilobyte 1000 vs Kibibyte 1024)</li>
+ *   <li>Abbreviated units (Kilobyte vs KB)</li>
+ *   <li>Locale adapted thousand separators  (1300 vs 1,300 vs 1 300)</li>
+ *   <li>Threshold at which bytes are displayed with a higher prefix
+ *   (e.g. set it to 15000 so that 14333 --> 14,333 Bytes and 15672 --> 15.672 Kilobytes</li>
+ *   <li>Precision for printing digits (30.2 Megabyte vs 30.21674 Megabyte).</li>
+ *   <li>Supports BigIntegers and BigDecimals up to Yottabyte/Yobibyte</li>
+ * </ul>
+ * <p>
+ * 
+ * @see UnitsService#registerFormatter(ByteFormatter, key)
+ */
 public class DefaultByteFormatter implements ByteFormatter {
 	
 	public static class Builder {
 		
 		private BaseUnit baseUnit = BaseUnit.DEFAULT;
-		private Language language = Language.EN;
 		private boolean abbreviate = false;
 		private boolean useThousandSeparators = true;
-		private long threshold = -1;
+		private BigDecimal threshold = BigDecimal.valueOf(-1L);
 		private int precision = 3;
 		
 		public Builder asBase(BaseUnit baseUnit) {
@@ -27,6 +55,10 @@ public class DefaultByteFormatter implements ByteFormatter {
 		}
 		
 		public Builder scaleUpThreshold(long threshold) {
+			this.threshold = BigDecimal.valueOf(threshold);
+			return this;
+		}
+		public Builder scaleUpThreshold(BigDecimal threshold) {
 			this.threshold = threshold;
 			return this;
 		}
@@ -62,14 +94,20 @@ public class DefaultByteFormatter implements ByteFormatter {
 	private BaseUnit baseUnit;
 	private boolean abbreviate;
 	private boolean useThousandSeparators;
-	private long threshold;
+	private final BigDecimal threshold;
+	private final BigDecimal unitBig;
+	private final BigDecimal maximumPossibleValue;
+	private final BigDecimal naturalLogOfUnit;
 	private int precision;
+	private int unit;
 	private final List<String> unitMapper;
+	// Thin space to separate number from unit
 	private char unitSeperator = '\u2009';
 	
 	
-	private static final long MAXIMUM_BASE_10_NUMBER = (long) 1000e11 - 1;
-	private static final long MAXIMUM_BASE_2_NUMBER = ((long) Math.pow(1024, 9)) - 1;
+	public static final BigDecimal MAXIMUM_BASE_10_NUMBER =  new BigDecimal("1e27").subtract(BigDecimal.ONE);
+	// 2^90 - 1 is the highest number representable by a Yobibyte
+	public static final BigDecimal MAXIMUM_BASE_2_NUMBER = new BigDecimal("1237940039285380274899124223");
 	
 	private DecimalFormat formatter;
 	
@@ -82,28 +120,37 @@ public class DefaultByteFormatter implements ByteFormatter {
 	
 	private List<String> base10Units;
     private List<String> base2Units;
+    private final BigDecimal THOUSAND = BigDecimal.valueOf(1000L);
+    private final BigDecimal THOUSAND_TWENTY_FOUR = BigDecimal.valueOf(1024L);
 
 	protected DefaultByteFormatter(
 			BaseUnit baseUnit, 
 			boolean abbreviate,
-			long scaleUpThreshold,
+			BigDecimal scaleUpThreshold,
 			boolean useThousandSeparators,
 			int precision
 	) {
 		this.baseUnit = baseUnit;
 		this.abbreviate = abbreviate;
-		this.threshold = scaleUpThreshold <= 0 ? 1000 : scaleUpThreshold;
+		this.threshold = scaleUpThreshold.compareTo(BigDecimal.ZERO) <= 0 ? THOUSAND : scaleUpThreshold;
 		this.useThousandSeparators = useThousandSeparators;
 		this.precision = precision;
 		initializeStrings();
 		unitMapper = selectUnitMapper();
 		formatter = createNumberFormatter();
+		
+		unit = baseUnit == BaseUnit.BASE_10 ? 1000 : 1024;
+		unitBig = baseUnit == BaseUnit.BASE_10 ? THOUSAND : THOUSAND_TWENTY_FOUR;
+		maximumPossibleValue = baseUnit == BaseUnit.BASE_10 ? MAXIMUM_BASE_10_NUMBER : MAXIMUM_BASE_2_NUMBER;
+		naturalLogOfUnit = BigDecimal.valueOf(Math.log(unit));
 	}
 	
 	private DecimalFormat createNumberFormatter() {
 		var decimalFormatter = new DecimalFormat("#." + "#".repeat(precision));
 		var symbols = decimalFormatter.getDecimalFormatSymbols();
 		if (useThousandSeparators) {
+			decimalFormatter.setGroupingUsed(true);
+			decimalFormatter.setGroupingSize(3);
 			symbols.setGroupingSeparator(Messages.LocaleThousandSeparator.charAt(0));
 		} else {
 			decimalFormatter.setGroupingUsed(false);
@@ -154,79 +201,99 @@ public class DefaultByteFormatter implements ByteFormatter {
 	 * @param bytes
 	 * @return
 	 */
-	public String humanReadableByteCount(BigInteger bytes) {
+	public String humanReadableByteCount(BigDecimal bytes) {
+		checkValue(bytes);
 		
-		int unit = baseUnit == BaseUnit.BASE_10 ? 1000 : 1024;
-		
-		if (bytes < threshold) {
-			return concat(bytes, 1000, unitMapper.get(0));
+		if (bytes.compareTo(threshold) < 0) {
+			return concat(bytes, THOUSAND, unitMapper.get(0));
 		}
 
-		int exp = (int) (Math.log(bytes) / Math.log(unit));
+		int exp = BigDecimal.valueOf(BigMath.logBigDecimal(bytes)).
+				divideToIntegralValue(naturalLogOfUnit).intValue();
 
 		// In the edge case when threshold is set below 1000, set the exp to 1 (=1000)
-		if (bytes < 1000) {
+		if (bytes.compareTo(THOUSAND) < 0) {
 			exp = 1;
 		}
-		double convertedBytes = bytes / Math.pow(unit, exp);
-		return concat(convertedBytes, (long) Math.pow(unit, exp), unitMapper.get(exp));
+		BigDecimal unitSize = unitBig.pow(exp);
+		BigDecimal convertedBytes = bytes.divide(unitSize);
+		return concat(convertedBytes, unitSize, unitMapper.get(exp));
 	}
 	
 	/**
 	 * 
 	 * @param bytes
-	 * @param reference
+	 * @param unitSize
 	 * @param unit
 	 * @return
 	 */
-	private String concat(double bytes, long reference, String unit) {
+	private String concat(BigDecimal bytes, BigDecimal unitSize, String unit) {
 		// Append an s if not abbreviated and either bytes = 1 or exactly divided.
-		boolean isOne = bytes == 1;
-		boolean isOneWithUnit = reference > 1 && bytes % reference == 0;
+		boolean isOne = bytes.compareTo(BigDecimal.ONE) == 0;
+		// Remainder is at position 2 of returned array.
+		BigDecimal remainder = bytes.divideAndRemainder(unitSize)[1];
+		boolean isOneWithUnit = unitSize.compareTo(BigDecimal.ONE) > 0 &&
+				remainder.compareTo(BigDecimal.ZERO) == 0;
 		
+		// Only append a plural 's' if is not 1 (byte = 1) or divides
+		// a unit cleanly (1000 bytes = 1 Kilobyte)
 		if (!abbreviate && !isOne && !isOneWithUnit) {
 			unit += 's';
 		}
 		return formatter.format(bytes) + unitSeperator + unit; 
 	}
 	
-	private void checkExponent(int exponent) {
-		if (exponent >= unitMapper.size()) {
-			throw new IllegalArgumentException("");
+	private void checkValue(BigDecimal value) {
+		if (value.abs().compareTo(maximumPossibleValue) > 0) {
+			throw new IllegalArgumentException(
+					String.format(
+							"Value too big to format: %s. The maximum allowed value is %s",
+							formatter.format(value),
+							formatter.format(maximumPossibleValue)
+					)
+			);
 		}
 	}
 
 	@Override
 	public String format(long bytes) {
-		return humanReadableByteCount(bytes);
+		return humanReadableByteCount(BigDecimal.valueOf(bytes));
 	}
 
 
 
 	@Override
 	public String format(int bytes) {
-		return humanReadableByteCount(bytes);
+		return humanReadableByteCount(BigDecimal.valueOf(bytes));
 	}
 
 
 	@Override
 	public String format(short bytes) {
-		return humanReadableByteCount(bytes);
+		return humanReadableByteCount(BigDecimal.valueOf(bytes));
 	}
 
 
 	@Override
 	public String format(byte bytes) {
-		// TODO Auto-generated method stub
-		return null;
+		return humanReadableByteCount(BigDecimal.valueOf(bytes));
 	}
 
 
 
 	@Override
 	public String format(char bytes) {
-		// TODO Auto-generated method stub
-		return null;
+		return humanReadableByteCount(BigDecimal.valueOf(bytes));
+	}
+
+	@Override
+	public String format(BigDecimal bytes) {
+		return humanReadableByteCount(bytes);
+	}
+	
+	@Override
+	public String format(BigInteger bytes) {
+		return humanReadableByteCount(new BigDecimal(bytes));
 	}
 
 

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/Messages.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/Messages.java
@@ -1,0 +1,41 @@
+package org.jcryptool.core.util.units;
+
+import org.eclipse.osgi.util.NLS;
+
+public class Messages extends NLS {
+	
+    private static final String BUNDLE_NAME = "org.jcryptool.core.util.units.messages"; //$NON-NLS-1$
+    public static String unitByte;
+    public static String LocaleThousandSeparator;
+    public static String LocaleCommaSeparator;
+    
+    // Base 10 byte count
+    public static String unitKiloByte;
+    public static String unitMegaByte;
+    public static String unitGigaByte;
+    public static String unitTeraByte;
+    public static String unitPetaByte;
+    public static String unitExaByte;
+    public static String unitZettaByte;
+    public static String unitYottaByte;
+   
+    // Base 2 IEC byte count
+    public static String unitKibiByte;
+    public static String unitMebiByte;
+    public static String unitGibiByte;
+    public static String unitTebiByte;
+    public static String unitPebiByte;
+    public static String unitExbiByte;
+    public static String unitZebibyte;
+    public static String unitYobiByte;
+    
+    
+    
+    static {
+        // initialize resource bundle
+        NLS.initializeMessages(BUNDLE_NAME, Messages.class);
+    }
+    
+    private Messages() {}
+
+}

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/Messages.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/Messages.java
@@ -3,12 +3,12 @@ package org.jcryptool.core.util.units;
 import org.eclipse.osgi.util.NLS;
 
 public class Messages extends NLS {
-	
+
     private static final String BUNDLE_NAME = "org.jcryptool.core.util.units.messages"; //$NON-NLS-1$
     public static String unitByte;
     public static String LocaleThousandSeparator;
     public static String LocaleCommaSeparator;
-    
+
     // Base 10 byte count
     public static String unitKiloByte;
     public static String unitMegaByte;
@@ -18,7 +18,7 @@ public class Messages extends NLS {
     public static String unitExaByte;
     public static String unitZettaByte;
     public static String unitYottaByte;
-   
+
     // Base 2 IEC byte count
     public static String unitKibiByte;
     public static String unitMebiByte;
@@ -28,14 +28,13 @@ public class Messages extends NLS {
     public static String unitExbiByte;
     public static String unitZebibyte;
     public static String unitYobiByte;
-    
-    
-    
+
     static {
         // initialize resource bundle
         NLS.initializeMessages(BUNDLE_NAME, Messages.class);
     }
-    
-    private Messages() {}
+
+    private Messages() {
+    }
 
 }

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/UnitsService.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/UnitsService.java
@@ -9,13 +9,371 @@
 // -----END DISCLAIMER-----
 package org.jcryptool.core.util.units;
 
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jcryptool.core.util.units.DefaultByteFormatter.BaseUnit;
+
 /**
- * Utility class for all unit conversion / handling used in JCrypTool.
+ * Utility class for unit conversion / handling provided for all plugins.
  * 
- * @author Anatoli Barski
- * @version 1.0.0
+ * Currently supports pretty byte formatting.
+ * Supported functionality is 
+ * <ul>
+ *   <li>Base10 and Base2 Units (Kilobyte 1000 vs Kibibyte 1024)</li>
+ *   <li>Abbreviated units (Kilobyte vs KB)</li>
+ *   <li>Locale adapted thousand separators  (1300 vs 1,300 vs 1 300)</li>
+ *   <li>Threshold at which bytes are displayed with a higher prefix
+ *   (e.g. set it to 15000 so that 14333 --> 14,333 Bytes and 15672 --> 15.672 Kilobytes</li>
+ *   <li>Precision for printing digits (30.2 Megabyte vs 30.21674 Megabyte).</li>
+ *   <li>Supports BigIntegers and BigDecimals up to Yottabyte/Yobibyte</li>
+ * </ul>
+
  */
 public class UnitsService {
+
+    private static UnitsService instance;
+    private HashMap<String, ByteFormatter> formatterMap = new HashMap<>();
+    private final Set<String> defaults = new HashSet<>();
+	
+	private UnitsService() {
+    	formatterMap.put(KEY_DEFAULT, DEFAULT);
+    	formatterMap.put(KEY_BASE10, DEFAULT);
+    	formatterMap.put(KEY_BASE10_ABBREVIATED, BASE10_ABBREVIATED);
+    	formatterMap.put(KEY_BASE2, BASE2);
+    	formatterMap.put(KEY_BASE2_ABBREVIATED, BASE2);
+    	
+    	
+		defaults.add(KEY_DEFAULT);
+		defaults.add(KEY_BASE10);
+		defaults.add(KEY_BASE10_ABBREVIATED);
+		defaults.add(KEY_BASE2);
+		defaults.add(KEY_BASE2_ABBREVIATED);
+	}
+	
+	/**
+	 * Get the JCrypTool UnitsService ByteFormatter functionality
+	 * @return the singleton instance
+	 */
+	public static UnitsService get() {
+		if (UnitsService.instance == null) {
+			UnitsService.instance = new UnitsService();
+		}
+		return UnitsService.instance;
+	}
+
+	
+	private final String KEY_DEFAULT = "__default";
+	private final String KEY_BASE10 = "__default";
+	private final String KEY_BASE10_ABBREVIATED = "__default_abbreviated";
+	private final String KEY_BASE2 = "__default_base2";
+	private final String KEY_BASE2_ABBREVIATED = "__default_base2_abbreviated";
+	
+
+	/**
+	 * Make your own {@linkplain ByteFormatter} available for {@link UnitsService#getFormatter(myFormatter)} and
+	 * {@link UnitsService#format(bytes, myFormatter)}}
+	 * 
+	 * <p>
+	 * @implNote Your registered Formatters are available for all JCrypTool plugins. Please keep that in mind
+	 *           and do not rely on other's custom formatters.
+	 * </p>
+	 * @param formatter You can create your own ByteFormatter (with custom parameters like
+	 *                  precision, unit, minimum threshold for going to kilobytes) by calling
+	 *                  {@linkplain new DefaultByteFormater.Builder().yourParamsHere().build()}
+	 * @param key       A unique identifier to store the given {@code formatter}. As you share 
+	 *                  this registry with other plugins, try to choose a unique key.
+	 *                  You cannot override an existing entry, such a request will do nothing.
+	 *                  Don't use keys beginning with "__XYZ".
+	 */
+	public void registerFormatter(ByteFormatter formatter, String key) {
+		if (!formatterMap.containsKey(key)) {
+			formatterMap.put(key, formatter);
+		}
+	}
+
+	/**
+	 * De-register a custom Formatter. Calling with non-present keys will do nothing.
+	 * 
+	 * @implNote The registered Formatters are kept here once for all plugins,
+	 *           so you could delete other plugins custom formatters. Please don't do that.
+	 * 
+	 * @param key The target specified by its String key.
+	 */
+	public void deregisterFormatter(String key) {
+		if (defaults.contains(key)) {
+			throw new IllegalArgumentException("Default key " + key + " may not be de-registered");
+		}
+		formatterMap.remove(key);
+	}
+	
+	/**
+	 * Get a {@linkplain ByteFormatter} and start formatting.
+	 * 
+	 * <p>
+	 * There are default Formatters available, see below. As a shortcut,
+	 * you can also call {@link UnitsService#format(bytes, formatterKey)} with your
+	 * registered key.
+	 * </p>
+	 * 
+	 * <p>
+	 * You can create your own {@link ByteFormatter} (with custom parameters like
+	 * precision, unit, minimum threshold for going to kilobytes, etc.) by calling
+	 * {@linkplain new DefaultByteFormater.Builder().yourParamsHere().build()}
+	 * </p>
+	 * 
+	 *@throws IllegalArgumentException on requesting a Formatter key which is not registered.
+	 *        You can call {@link UnitsService#isFormatterAvailable(key)} to check beforehand. 
+	 
+	 * @param   key The target ID 
+	 * @return  A {@linkplain ByteFormatter} which can be used to call format() on various integer datatypes.
+	 * 
+	 * @see UnitsService#registerFormatter(formatter, key)
+	 * @see UnitsService#DEFAULT
+	 * @see UnitsService#BASE10
+	 * @see UnitsService#BASE10_ABBREVIATED
+	 * @see UnitsService#BASE2
+	 * @see UnitsService#BASE2_ABBREVIATED
+	 */
+	public ByteFormatter getFormatter(String key) {
+		if (formatterMap.containsKey(key)) {
+			return formatterMap.get(key);
+		}
+		throw new IllegalArgumentException("Requested formatter not registered.");
+	}
+	
+	
+	/**
+	 * Check if a custom Formatter is present in the UnitsService Byteformatter service.
+	 * @param key The target Formatter key.
+	 * @return    {@code true} when present, {@code false} otherwise.
+	 */
+	public boolean isFormatterAvailable(String key) {
+		return formatterMap.containsKey(key);
+	}
+
+
+	/**
+	 * Simply format your bytes without having to mind about locales/languages.
+	 * 
+	 * <p>
+	 * This is a shortcut for {@linkplain UnitsService.DEFAULT.format(bytes)}
+	 * </p>
+	 * 
+	 * <p>
+	 * There are other predefined Formatters available, see below. 
+	 * If you want to parameterize / adapt your own settings, take a look at {@link DefaultByteFormatter} and
+	 * {@link UnitsService#registerFormatter(ByteFormatter, key)}.
+	 * There you have plenty of options to customize your settings such as 
+	 * precision, unit, minimum threshold for going to kilobytes, etc.
+	 * Register them with {@link UnitsService#registerFormatter(ByteFormatter, key)} and use them with
+	 * {@link UnitsService#getFormatter(key)} or directly with {@link UnitsService#format(bytes, key)}.
+	 * </p>
+	 * @param bytes Target number to format.
+	 * @return      A nicely formatted String with a Byte unit according to the input size
+	 *              (base 10 Kilobytes, Megabytes).
+	 *
+	 * @see UnitsService#DEFAULT
+	 * @see DefaultByteFormatter
+	 * @see UnitsService#registerFormatter(ByteFormatter, key)
+	 * @see UnitsService#format(bytes, key)
+	 */
+    public static String format(long bytes) {
+    	return DEFAULT.format(bytes);
+    }
+    
+    /**
+	 * Simply format your bytes without having to mind about locales/languages.
+	 * Specify a custom target formatter with {@code key}, which has to be registered beforehand.
+	 * 
+	 * <p>
+	 * There are predefined Formatters available, see below. 
+	 * If you want to register your own Formatter on which you can parameterize / adapt
+	 * your own settings, take a look at {@link DefaultByteFormatter} and
+	 * {@link UnitsService#registerFormatter(ByteFormatter, key)}.
+	 * There you have plenty of options to customize your settings such as 
+	 * precision, unit, minimum threshold for going to kilobytes, etc.
+	 * Register them with {@link UnitsService#registerFormatter(ByteFormatter, key)} and use them with
+	 * {@link UnitsService#getFormatter(key) or UnitsService#format(bytes, key)} directly.
+	 * </p>
+     * 
+	 * <p>
+	 * This is a shortcut for {@linkplain UnitsService.get().getFormatter(key).format(bytes)}
+	 * </p>
+	 * 
+     * @param bytes          Target number to format
+     * @param formatterKey   A registered Formatter key to use.
+     * 
+     * @return      A nicely formatted String with a Byte unit as provided
+     *              by the specified Formatter class.
+	 *
+	 * @see UnitsService#registerFormatter(ByteFormatter, key)
+	 * @see UnitsService#DEFAULT
+	 * @see DefaultByteFormatter
+	 * @see UnitsService#format(bytes)
+	 */
+    public static String format(long bytes, String formatterKey) {
+    	return UnitsService.get().getFormatter(formatterKey).format(bytes);
+    }
+    
+    
+    /**
+     * Nicely format {@code BigInteger} bytes, see {@link UnitsService#format(long bytes)}
+     * @param bytes          Target number to format
+     * @return      A nicely formatted String with a Byte unit according to the input size
+	 *              (base 10 Kilobytes, Megabytes).
+     */
+    public static String format(BigInteger bytes) {
+    	return DEFAULT.format(bytes);
+    }
+    
+    /**
+     * Nicely format {@code BigInteger} bytes, see {@link UnitsService#format(long bytes, String formatterKey)}
+     * @param bytes          Target number to format
+     * @param formatterKey   A registered Formatter key to use.
+     * @return      A nicely formatted String with a Byte unit as provided
+     *              by the specified Formatter class.
+     */
+    public static String format(BigInteger bytes, String formatterKey) {
+    	return UnitsService.get().getFormatter(formatterKey).format(bytes);
+    }
+    
+    /**
+     * The default byte formatter which uses base10 (Kilobyte, Megabyte) units.
+     * It automatically adapts to the locale (English, German).
+     * The unit is written out. Numbers are converted as soon as they reach the
+     * next unit. The precision defaults to 3, so numbers may be rounded
+     * 
+     * <p>
+     * Use {@link UnitsService.get().registerFormatter()} to register your own ByteFormatter.
+     * There is a default implementation available which you can parameterize at {@link DefaultByteFormatter}
+     * </p>
+     * 
+     * <ul>
+     * 	<li>986     --> 986 bytes / 986 Bytes</li>
+     * 	<li>1024    --> 1.024 kilobytes / 1,024 Kilobytes</li>
+     * 	<li>14368   --> 14.368 kilobytes / 14,368 Kilobytes</li>
+     * 	<li>5743487 --> 5.743 megabytes / 5,743 Megabytes</li>
+     * </ul>
+     * 
+     * @see UnitsService.registerFormatter
+     * @see DefaultByteFormatter
+     * @see BASE10_ABBREVIATED
+     * @see BASE2
+     * @see BASE2_ABBREVIATED
+     */
+    public static ByteFormatter DEFAULT = new DefaultByteFormatter.Builder().build();
+    
+    /**
+     * A basic byte formatter which uses base10 (Kilobyte, Megabyte) units.
+     * It automatically adapts to the locale (English, German).
+     * The unit is written out. Numbers are converted as soon as they reach the
+     * next unit. The precision defaults to 3, so numbers may be rounded
+     * 
+     * <p>
+     * Use {@link UnitsService.get().registerFormatter()} to register your own ByteFormatter.
+     * There is a default implementation available which you can parameterize at {@link DefaultByteFormatter}
+     * </p>
+     * 
+     * <ul>
+     * 	<li>986     --> 986 bytes / 986 Bytes</li>
+     * 	<li>1024    --> 1.024 kilobytes / 1,024 Kilobytes</li>
+     * 	<li>14368   --> 14.368 kilobytes / 14,368 Kilobytes</li>
+     * 	<li>5743487 --> 5.743 megabytes / 5,743 Megabytes</li>
+     * </ul>
+     * 
+     * @see UnitsService.registerFormatter
+     * @see DefaultByteFormatter
+     * @see DEFAULT
+     * @see BASE10_ABBREVIATED
+     * @see BASE2
+     * @see BASE2_ABBREVIATED
+     */
+    public static ByteFormatter BASE10 = DEFAULT;
+    /**
+     * A basic byte formatter which uses base10 (KB, MB) units.
+     * It automatically adapts to the locale (English, German).
+     * The unit is abbreviated out. Numbers are converted as soon as they reach the
+     * next unit. The precision defaults to 3, so numbers may be rounded
+     * 
+     * <p>
+     * Use {@link UnitsService.get().registerFormatter()} to register your own ByteFormatter.
+     * There is a default implementation available which you can parameterize at {@link DefaultByteFormatter}
+     * </p>
+     * 
+     * <ul>
+     * 	<li>986     --> 986 B / 986 B</li>
+     * 	<li>1024    --> 1.024 KB / 1,024 KB</li>
+     * 	<li>14368   --> 14.368 KB / 14,368 KB</li>
+     * 	<li>5743487 --> 5.743 MB / 5,743</li>
+     * </ul>
+     * 
+     * @see UnitsService.registerFormatter
+     * @see DefaultByteFormatter
+     * @see DEFAULT
+     * @see BASE10
+     * @see BASE2
+     * @see BASE2_ABBREVIATED
+     */
+    public static ByteFormatter BASE10_ABBREVIATED =
+    		new DefaultByteFormatter.Builder().abbreviateUnit(false).build();
+    /**
+     * A basic byte formatter which uses written-out base2 (Kibibyte, Mebibyte) IEC units.
+     * It automatically adapts to the locale (English, German).
+     * The unit is abbreviated out. Numbers are converted as soon as they reach the
+     * next unit. The precision defaults to 3, so numbers may be rounded
+     * 
+     * <p>
+     * Use {@link UnitsService.get().registerFormatter()} to register your own ByteFormatter.
+     * There is a default implementation available which you can parameterize at {@link DefaultByteFormatter}
+     * </p>
+     * 
+     * <ul>
+     * 	<li>986     --> 986 bytes / 986 Bytes</li>
+     * 	<li>1024    --> 1 kibibyte / 1 Kibibyte</li>
+     * 	<li>143687  --> 14.031 kibibytes /  14,031 Kibibytes</li>
+     * 	<li>5743487 --> 5.743 mebibytes / 5,743 Mebibytes</li>
+     * </ul>
+     * 
+     * @see UnitsService.registerFormatter
+     * @see DefaultByteFormatter
+     * @see DEFAULT
+     * @see BASE10
+     * @see BASE10_ABBREVIATED
+     * @see BASE2_ABBREVIATED
+     */
+    public static ByteFormatter BASE2 =
+    		new DefaultByteFormatter.Builder().asBase(BaseUnit.BASE_2).build();
+    /**
+     * A basic byte formatter which uses shortened base2 (KiB, MiB) IEC units.
+     * It automatically adapts to the locale (English, German).
+     * Numbers are converted as soon as they reach the next unit.
+     * The precision defaults to 3, so numbers may be rounded.
+     * 
+     * <p>
+     * Use {@link UnitsService.get().registerFormatter()} to register your own ByteFormatter.
+     * There is a default implementation available which you can parameterize at {@link DefaultByteFormatter}
+     * </p>
+     * 
+     * <ul>
+     * 	<li>986     --> 986 bytes / 986 Bytes</li>
+     * 	<li>1024    --> 1 KiB / 1 KiB</li>
+     * 	<li>143687  --> 14.031 KiB /  14,031 KiB</li>
+     * 	<li>5743487 --> 5.743 MiB / 5,743 MiB</li>
+     * </ul>
+     * 
+     * @see UnitsService.registerFormatter
+     * @see DefaultByteFormatter
+     * @see DEFAULT
+     * @see BASE10
+     * @see BASE10_ABBREVIATED
+     * @see BASE2
+     */
+    public static ByteFormatter BASE2_ABBREVIATED =
+    		new DefaultByteFormatter.Builder().abbreviateUnit(false).asBase(BaseUnit.BASE_2).build();
+    
 
     /**
      * converts byte count to a human readable string Example output: SI BINARY
@@ -35,5 +393,12 @@ public class UnitsService {
         String pre = (si ? "kMGTPE" : "KMGTPE").charAt(exp - 1) + (si ? "" : "i"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
         return String.format("%.1f %sB", bytes / Math.pow(unit, exp), pre); //$NON-NLS-1$
     }
+    
+    public static void main(String[] args) {
+    	ByteFormatter myByteFormatter = new DefaultByteFormatter.Builder().build();
+    	System.out.println(myByteFormatter.format(983));
+    }
 
+    
+    
 }

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/UnitsService.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/UnitsService.java
@@ -425,7 +425,11 @@ public class UnitsService {
      * 
      * @return byte count including units as string
      * 
-     * @deprecated Will soon be replaced by
+     * @deprecated Will soon be replaced by {@link UnitsService#format(long)} see also the new
+     * UnitsService functionality at {@link UnitsService#get()}
+     * 
+     * @see UnitsService#DEFAULT
+     * @see DefaultByteFormatter
      */
     public static String humanReadableByteCount(long bytes, boolean si) {
         int unit = si ? 1000 : 1024;

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/UnitsService.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/UnitsService.java
@@ -19,372 +19,414 @@ import org.jcryptool.core.util.units.DefaultByteFormatter.BaseUnit;
 /**
  * Utility class for unit conversion / handling provided for all plugins.
  * 
- * Currently supports pretty byte formatting.
- * Supported functionality is 
+ * Currently supports pretty byte formatting. Supported functionality is
  * <ul>
- *   <li>Base10 and Base2 Units (Kilobyte 1000 vs Kibibyte 1024)</li>
- *   <li>Abbreviated units (Kilobyte vs KB)</li>
- *   <li>Locale adapted thousand separators  (1300 vs 1,300 vs 1 300)</li>
- *   <li>Threshold at which bytes are displayed with a higher prefix
- *   (e.g. set it to 15000 so that 14333 --> 14,333 Bytes and 15672 --> 15.672 Kilobytes</li>
- *   <li>Precision for printing digits (30.2 Megabyte vs 30.21674 Megabyte).</li>
- *   <li>Supports BigIntegers and BigDecimals up to Yottabyte/Yobibyte</li>
+ * <li>Base10 and Base2 Units (Kilobyte 1000 vs Kibibyte 1024)</li>
+ * <li>Abbreviated units (Kilobyte vs KB)</li>
+ * <li>Locale adapted thousand separators (1300 vs 1,300 vs 1 300)</li>
+ * <li>Threshold at which bytes are displayed with a higher prefix (e.g. set it
+ * to 15000 so that 14333 --> 14,333 Bytes and 15672 --> 15.672 Kilobytes</li>
+ * <li>Precision for printing digits (30.2 Megabyte vs 30.21674 Megabyte).</li>
+ * <li>Supports BigIntegers and BigDecimals up to Yottabyte/Yobibyte</li>
  * </ul>
-
+ * 
  */
 public class UnitsService {
+
+    // I think this value is reasonable to prevent this structure to somehow become
+    // huge.
+    private final int MAXIMUM_REGISTERABLE_SIZE = 16_384;
 
     private static UnitsService instance;
     private HashMap<String, ByteFormatter> formatterMap = new HashMap<>();
     private final Set<String> defaults = new HashSet<>();
-	
-	private UnitsService() {
-    	formatterMap.put(KEY_DEFAULT, DEFAULT);
-    	formatterMap.put(KEY_BASE10, DEFAULT);
-    	formatterMap.put(KEY_BASE10_ABBREVIATED, BASE10_ABBREVIATED);
-    	formatterMap.put(KEY_BASE2, BASE2);
-    	formatterMap.put(KEY_BASE2_ABBREVIATED, BASE2);
-    	
-    	
-		defaults.add(KEY_DEFAULT);
-		defaults.add(KEY_BASE10);
-		defaults.add(KEY_BASE10_ABBREVIATED);
-		defaults.add(KEY_BASE2);
-		defaults.add(KEY_BASE2_ABBREVIATED);
-	}
-	
-	/**
-	 * Get the JCrypTool UnitsService ByteFormatter functionality
-	 * @return the singleton instance
-	 */
-	public static UnitsService get() {
-		if (UnitsService.instance == null) {
-			UnitsService.instance = new UnitsService();
-		}
-		return UnitsService.instance;
-	}
 
-	
-	private final String KEY_DEFAULT = "__default";
-	private final String KEY_BASE10 = "__default";
-	private final String KEY_BASE10_ABBREVIATED = "__default_abbreviated";
-	private final String KEY_BASE2 = "__default_base2";
-	private final String KEY_BASE2_ABBREVIATED = "__default_base2_abbreviated";
-	
+    private UnitsService() {
+        formatterMap.put(KEY_DEFAULT, DEFAULT);
+        formatterMap.put(KEY_BASE10, DEFAULT);
+        formatterMap.put(KEY_BASE10_ABBREVIATED, BASE10_ABBREVIATED);
+        formatterMap.put(KEY_BASE2, BASE2);
+        formatterMap.put(KEY_BASE2_ABBREVIATED, BASE2);
 
-	/**
-	 * Make your own {@linkplain ByteFormatter} available for {@link UnitsService#getFormatter(myFormatter)} and
-	 * {@link UnitsService#format(bytes, myFormatter)}}
-	 * 
-	 * <p>
-	 * @implNote Your registered Formatters are available for all JCrypTool plugins. Please keep that in mind
-	 *           and do not rely on other's custom formatters.
-	 * </p>
-	 * @param formatter You can create your own ByteFormatter (with custom parameters like
-	 *                  precision, unit, minimum threshold for going to kilobytes) by calling
-	 *                  {@linkplain new DefaultByteFormater.Builder().yourParamsHere().build()}
-	 * @param key       A unique identifier to store the given {@code formatter}. As you share 
-	 *                  this registry with other plugins, try to choose a unique key.
-	 *                  You cannot override an existing entry, such a request will do nothing.
-	 *                  Don't use keys beginning with "__XYZ".
-	 */
-	public void registerFormatter(ByteFormatter formatter, String key) {
-		if (!formatterMap.containsKey(key)) {
-			formatterMap.put(key, formatter);
-		}
-	}
+        defaults.add(KEY_DEFAULT);
+        defaults.add(KEY_BASE10);
+        defaults.add(KEY_BASE10_ABBREVIATED);
+        defaults.add(KEY_BASE2);
+        defaults.add(KEY_BASE2_ABBREVIATED);
+    }
 
-	/**
-	 * De-register a custom Formatter. Calling with non-present keys will do nothing.
-	 * 
-	 * @implNote The registered Formatters are kept here once for all plugins,
-	 *           so you could delete other plugins custom formatters. Please don't do that.
-	 * 
-	 * @param key The target specified by its String key.
-	 */
-	public void deregisterFormatter(String key) {
-		if (defaults.contains(key)) {
-			throw new IllegalArgumentException("Default key " + key + " may not be de-registered");
-		}
-		formatterMap.remove(key);
-	}
-	
-	/**
-	 * Get a {@linkplain ByteFormatter} and start formatting.
-	 * 
-	 * <p>
-	 * There are default Formatters available, see below. As a shortcut,
-	 * you can also call {@link UnitsService#format(bytes, formatterKey)} with your
-	 * registered key.
-	 * </p>
-	 * 
-	 * <p>
-	 * You can create your own {@link ByteFormatter} (with custom parameters like
-	 * precision, unit, minimum threshold for going to kilobytes, etc.) by calling
-	 * {@linkplain new DefaultByteFormater.Builder().yourParamsHere().build()}
-	 * </p>
-	 * 
-	 *@throws IllegalArgumentException on requesting a Formatter key which is not registered.
-	 *        You can call {@link UnitsService#isFormatterAvailable(key)} to check beforehand. 
-	 
-	 * @param   key The target ID 
-	 * @return  A {@linkplain ByteFormatter} which can be used to call format() on various integer datatypes.
-	 * 
-	 * @see UnitsService#registerFormatter(formatter, key)
-	 * @see UnitsService#DEFAULT
-	 * @see UnitsService#BASE10
-	 * @see UnitsService#BASE10_ABBREVIATED
-	 * @see UnitsService#BASE2
-	 * @see UnitsService#BASE2_ABBREVIATED
-	 */
-	public ByteFormatter getFormatter(String key) {
-		if (formatterMap.containsKey(key)) {
-			return formatterMap.get(key);
-		}
-		throw new IllegalArgumentException("Requested formatter not registered.");
-	}
-	
-	
-	/**
-	 * Check if a custom Formatter is present in the UnitsService Byteformatter service.
-	 * @param key The target Formatter key.
-	 * @return    {@code true} when present, {@code false} otherwise.
-	 */
-	public boolean isFormatterAvailable(String key) {
-		return formatterMap.containsKey(key);
-	}
+    /**
+     * Get the JCrypTool UnitsService ByteFormatter functionality
+     * 
+     * @return the singleton instance
+     */
+    public static UnitsService get() {
+        if (UnitsService.instance == null) {
+            UnitsService.instance = new UnitsService();
+        }
+        return UnitsService.instance;
+    }
 
+    private final String KEY_DEFAULT = "__default";
+    private final String KEY_BASE10 = "__default";
+    private final String KEY_BASE10_ABBREVIATED = "__default_abbreviated";
+    private final String KEY_BASE2 = "__default_base2";
+    private final String KEY_BASE2_ABBREVIATED = "__default_base2_abbreviated";
 
-	/**
-	 * Simply format your bytes without having to mind about locales/languages.
-	 * 
-	 * <p>
-	 * This is a shortcut for {@linkplain UnitsService.DEFAULT.format(bytes)}
-	 * </p>
-	 * 
-	 * <p>
-	 * There are other predefined Formatters available, see below. 
-	 * If you want to parameterize / adapt your own settings, take a look at {@link DefaultByteFormatter} and
-	 * {@link UnitsService#registerFormatter(ByteFormatter, key)}.
-	 * There you have plenty of options to customize your settings such as 
-	 * precision, unit, minimum threshold for going to kilobytes, etc.
-	 * Register them with {@link UnitsService#registerFormatter(ByteFormatter, key)} and use them with
-	 * {@link UnitsService#getFormatter(key)} or directly with {@link UnitsService#format(bytes, key)}.
-	 * </p>
-	 * @param bytes Target number to format.
-	 * @return      A nicely formatted String with a Byte unit according to the input size
-	 *              (base 10 Kilobytes, Megabytes).
-	 *
-	 * @see UnitsService#DEFAULT
-	 * @see DefaultByteFormatter
-	 * @see UnitsService#registerFormatter(ByteFormatter, key)
-	 * @see UnitsService#format(bytes, key)
-	 */
+    /**
+     * Make your own {@linkplain ByteFormatter} available for
+     * {@link UnitsService#getFormatter(myFormatter)} and
+     * {@link UnitsService#format(bytes, myFormatter)}}
+     * 
+     * <p>
+     * 
+     * @implNote Your registered Formatters are available for all JCrypTool plugins.
+     *           Please keep that in mind and do not rely on other's custom
+     *           formatters.
+     *           </p>
+     * @param formatter You can create your own ByteFormatter (with custom
+     *                  parameters like precision, unit, minimum threshold for going
+     *                  to kilobytes) by calling {@linkplain new
+     *                  DefaultByteFormater.Builder().yourParamsHere().build()}
+     * @param key       A unique identifier to store the given {@code formatter}. As
+     *                  you share this registry with other plugins, try to choose a
+     *                  unique key. You cannot override an existing entry, such a
+     *                  request will do nothing. Don't use keys beginning with
+     *                  "__XYZ".
+     * 
+     * @throws IllegalStateException is the registry is full. You can check with
+     */
+    public void registerFormatter(ByteFormatter formatter, String key) {
+        if (formatterMap.size() + 1 >= MAXIMUM_REGISTERABLE_SIZE) {
+            throw new IllegalStateException("The ByteFormatter registry is full.");
+        }
+        if (!formatterMap.containsKey(key)) {
+            formatterMap.put(key, formatter);
+        }
+    }
+
+    /**
+     * De-register a custom Formatter. Calling with non-present keys will do
+     * nothing.
+     * 
+     * @implNote The registered Formatters are kept here once for all plugins, so
+     *           you could delete other plugins custom formatters. Please don't do
+     *           that.
+     * 
+     * @param key The target specified by its String key.
+     */
+    public void deregisterFormatter(String key) {
+        if (defaults.contains(key)) {
+            throw new IllegalArgumentException("Default key " + key + " may not be de-registered");
+        }
+        formatterMap.remove(key);
+    }
+
+    /**
+     * Get a {@linkplain ByteFormatter} and start formatting.
+     * 
+     * <p>
+     * There are default Formatters available, see below. As a shortcut, you can
+     * also call {@link UnitsService#format(bytes, formatterKey)} with your
+     * registered key.
+     * </p>
+     * 
+     * <p>
+     * You can create your own {@link ByteFormatter} (with custom parameters like
+     * precision, unit, minimum threshold for going to kilobytes, etc.) by calling
+     * {@linkplain new DefaultByteFormater.Builder().yourParamsHere().build()}
+     * </p>
+     * 
+     * @throws IllegalArgumentException on requesting a Formatter key which is not
+     *                                  registered. You can call
+     *                                  {@link UnitsService#isFormatterAvailable(key)}
+     *                                  to check beforehand.
+     * 
+     * @param key The target ID
+     * @return A {@linkplain ByteFormatter} which can be used to call format() on
+     *         various integer datatypes.
+     * 
+     * @see UnitsService#registerFormatter(formatter, key)
+     * @see UnitsService#DEFAULT
+     * @see UnitsService#BASE10
+     * @see UnitsService#BASE10_ABBREVIATED
+     * @see UnitsService#BASE2
+     * @see UnitsService#BASE2_ABBREVIATED
+     */
+    public ByteFormatter getFormatter(String key) {
+        if (formatterMap.containsKey(key)) {
+            return formatterMap.get(key);
+        }
+        throw new IllegalArgumentException("Requested formatter not registered.");
+    }
+
+    /**
+     * Check if a custom Formatter is present in the UnitsService Byteformatter
+     * service.
+     * 
+     * @param key The target Formatter key.
+     * @return {@code true} when present, {@code false} otherwise.
+     */
+    public boolean isFormatterAvailable(String key) {
+        return formatterMap.containsKey(key);
+    }
+
+    /**
+     * Check if a formatter can be registered in the map (usually should be
+     * possible, only fails for edge cases when the data structure is full)
+     * 
+     * @return true if a formatter can be registered, false otherwise
+     */
+    public boolean isRegisteringPossible() {
+        return formatterMap.size() - 1 < MAXIMUM_REGISTERABLE_SIZE;
+    }
+
+    /**
+     * Simply format your bytes without having to mind about locales/languages.
+     * 
+     * <p>
+     * This is a shortcut for {@linkplain UnitsService.DEFAULT.format(bytes)}
+     * </p>
+     * 
+     * <p>
+     * There are other predefined Formatters available, see below. If you want to
+     * parameterize / adapt your own settings, take a look at
+     * {@link DefaultByteFormatter} and
+     * {@link UnitsService#registerFormatter(ByteFormatter, key)}. There you have
+     * plenty of options to customize your settings such as precision, unit, minimum
+     * threshold for going to kilobytes, etc. Register them with
+     * {@link UnitsService#registerFormatter(ByteFormatter, key)} and use them with
+     * {@link UnitsService#getFormatter(key)} or directly with
+     * {@link UnitsService#format(bytes, key)}.
+     * </p>
+     * 
+     * @param bytes Target number to format.
+     * @return A nicely formatted String with a Byte unit according to the input
+     *         size (base 10 Kilobytes, Megabytes).
+     *
+     * @see UnitsService#DEFAULT
+     * @see DefaultByteFormatter
+     * @see UnitsService#registerFormatter(ByteFormatter, key)
+     * @see UnitsService#format(bytes, key)
+     */
     public static String format(long bytes) {
-    	return DEFAULT.format(bytes);
+        return DEFAULT.format(bytes);
     }
-    
+
     /**
-	 * Simply format your bytes without having to mind about locales/languages.
-	 * Specify a custom target formatter with {@code key}, which has to be registered beforehand.
-	 * 
-	 * <p>
-	 * There are predefined Formatters available, see below. 
-	 * If you want to register your own Formatter on which you can parameterize / adapt
-	 * your own settings, take a look at {@link DefaultByteFormatter} and
-	 * {@link UnitsService#registerFormatter(ByteFormatter, key)}.
-	 * There you have plenty of options to customize your settings such as 
-	 * precision, unit, minimum threshold for going to kilobytes, etc.
-	 * Register them with {@link UnitsService#registerFormatter(ByteFormatter, key)} and use them with
-	 * {@link UnitsService#getFormatter(key) or UnitsService#format(bytes, key)} directly.
-	 * </p>
+     * Simply format your bytes without having to mind about locales/languages.
+     * Specify a custom target formatter with {@code key}, which has to be
+     * registered beforehand.
      * 
-	 * <p>
-	 * This is a shortcut for {@linkplain UnitsService.get().getFormatter(key).format(bytes)}
-	 * </p>
-	 * 
-     * @param bytes          Target number to format
-     * @param formatterKey   A registered Formatter key to use.
+     * <p>
+     * There are predefined Formatters available, see below. If you want to register
+     * your own Formatter on which you can parameterize / adapt your own settings,
+     * take a look at {@link DefaultByteFormatter} and
+     * {@link UnitsService#registerFormatter(ByteFormatter, key)}. There you have
+     * plenty of options to customize your settings such as precision, unit, minimum
+     * threshold for going to kilobytes, etc. Register them with
+     * {@link UnitsService#registerFormatter(ByteFormatter, key)} and use them with
+     * {@link UnitsService#getFormatter(key) or UnitsService#format(bytes, key)}
+     * directly.
+     * </p>
      * 
-     * @return      A nicely formatted String with a Byte unit as provided
-     *              by the specified Formatter class.
-	 *
-	 * @see UnitsService#registerFormatter(ByteFormatter, key)
-	 * @see UnitsService#DEFAULT
-	 * @see DefaultByteFormatter
-	 * @see UnitsService#format(bytes)
-	 */
+     * <p>
+     * This is a shortcut for
+     * {@linkplain UnitsService.get().getFormatter(key).format(bytes)}
+     * </p>
+     * 
+     * @param bytes        Target number to format
+     * @param formatterKey A registered Formatter key to use.
+     * 
+     * @return A nicely formatted String with a Byte unit as provided by the
+     *         specified Formatter class.
+     *
+     * @see UnitsService#registerFormatter(ByteFormatter, key)
+     * @see UnitsService#DEFAULT
+     * @see DefaultByteFormatter
+     * @see UnitsService#format(bytes)
+     */
     public static String format(long bytes, String formatterKey) {
-    	return UnitsService.get().getFormatter(formatterKey).format(bytes);
+        return UnitsService.get().getFormatter(formatterKey).format(bytes);
     }
-    
-    
+
     /**
-     * Nicely format {@code BigInteger} bytes, see {@link UnitsService#format(long bytes)}
-     * @param bytes          Target number to format
-     * @return      A nicely formatted String with a Byte unit according to the input size
-	 *              (base 10 Kilobytes, Megabytes).
+     * Nicely format {@code BigInteger} bytes, see
+     * {@link UnitsService#format(long bytes)}
+     * 
+     * @param bytes Target number to format
+     * @return A nicely formatted String with a Byte unit according to the input
+     *         size (base 10 Kilobytes, Megabytes).
      */
     public static String format(BigInteger bytes) {
-    	return DEFAULT.format(bytes);
+        return DEFAULT.format(bytes);
     }
-    
+
     /**
-     * Nicely format {@code BigInteger} bytes, see {@link UnitsService#format(long bytes, String formatterKey)}
-     * @param bytes          Target number to format
-     * @param formatterKey   A registered Formatter key to use.
-     * @return      A nicely formatted String with a Byte unit as provided
-     *              by the specified Formatter class.
+     * Nicely format {@code BigInteger} bytes, see
+     * {@link UnitsService#format(long bytes, String formatterKey)}
+     * 
+     * @param bytes        Target number to format
+     * @param formatterKey A registered Formatter key to use.
+     * @return A nicely formatted String with a Byte unit as provided by the
+     *         specified Formatter class.
      */
     public static String format(BigInteger bytes, String formatterKey) {
-    	return UnitsService.get().getFormatter(formatterKey).format(bytes);
+        return UnitsService.get().getFormatter(formatterKey).format(bytes);
     }
-    
+
     /**
-     * The default byte formatter which uses base10 (Kilobyte, Megabyte) units.
-     * It automatically adapts to the locale (English, German).
-     * The unit is written out. Numbers are converted as soon as they reach the
-     * next unit. The precision defaults to 3, so numbers may be rounded
+     * The default byte formatter which uses base10 (Kilobyte, Megabyte) units. It
+     * automatically adapts to the locale (English, German). The unit is written
+     * out. Numbers are converted as soon as they reach the next unit. The precision
+     * defaults to 3, so numbers may be rounded
      * 
      * <p>
-     * Use {@link UnitsService.get().registerFormatter()} to register your own ByteFormatter.
-     * There is a default implementation available which you can parameterize at {@link DefaultByteFormatter}
+     * Use {@link UnitsService.get().registerFormatter()} to register your own
+     * ByteFormatter. There is a default implementation available which you can
+     * parameterize at {@link DefaultByteFormatter}
      * </p>
      * 
      * <ul>
-     * 	<li>986     --> 986 bytes / 986 Bytes</li>
-     * 	<li>1024    --> 1.024 kilobytes / 1,024 Kilobytes</li>
-     * 	<li>14368   --> 14.368 kilobytes / 14,368 Kilobytes</li>
-     * 	<li>5743487 --> 5.743 megabytes / 5,743 Megabytes</li>
+     * <li>986 --> 986 bytes / 986 Bytes</li>
+     * <li>1024 --> 1.024 kilobytes / 1,024 Kilobytes</li>
+     * <li>14368 --> 14.368 kilobytes / 14,368 Kilobytes</li>
+     * <li>5743487 --> 5.743 megabytes / 5,743 Megabytes</li>
      * </ul>
      * 
-     * @see UnitsService.registerFormatter
+     * @see UnitsService#registerFormatter()
      * @see DefaultByteFormatter
-     * @see BASE10_ABBREVIATED
-     * @see BASE2
-     * @see BASE2_ABBREVIATED
+     * @see UnitsService#BASE10_ABBREVIATED
+     * @see UnitsService#BASE2
+     * @see UnitsService#BASE2_ABBREVIATED
      */
     public static ByteFormatter DEFAULT = new DefaultByteFormatter.Builder().build();
-    
+
     /**
-     * A basic byte formatter which uses base10 (Kilobyte, Megabyte) units.
-     * It automatically adapts to the locale (English, German).
-     * The unit is written out. Numbers are converted as soon as they reach the
-     * next unit. The precision defaults to 3, so numbers may be rounded
+     * A basic byte formatter which uses base10 (Kilobyte, Megabyte) units. It
+     * automatically adapts to the locale (English, German). The unit is written
+     * out. Numbers are converted as soon as they reach the next unit. The precision
+     * defaults to 3, so numbers may be rounded
      * 
      * <p>
-     * Use {@link UnitsService.get().registerFormatter()} to register your own ByteFormatter.
-     * There is a default implementation available which you can parameterize at {@link DefaultByteFormatter}
+     * Use {@link UnitsService.get().registerFormatter()} to register your own
+     * ByteFormatter. There is a default implementation available which you can
+     * parameterize at {@link DefaultByteFormatter}
      * </p>
      * 
      * <ul>
-     * 	<li>986     --> 986 bytes / 986 Bytes</li>
-     * 	<li>1024    --> 1.024 kilobytes / 1,024 Kilobytes</li>
-     * 	<li>14368   --> 14.368 kilobytes / 14,368 Kilobytes</li>
-     * 	<li>5743487 --> 5.743 megabytes / 5,743 Megabytes</li>
+     * <li>986 --> 986 bytes / 986 Bytes</li>
+     * <li>1024 --> 1.024 kilobytes / 1,024 Kilobytes</li>
+     * <li>14368 --> 14.368 kilobytes / 14,368 Kilobytes</li>
+     * <li>5743487 --> 5.743 megabytes / 5,743 Megabytes</li>
      * </ul>
      * 
-     * @see UnitsService.registerFormatter
+     * @see UnitsService#registerFormatter()
      * @see DefaultByteFormatter
-     * @see DEFAULT
-     * @see BASE10_ABBREVIATED
-     * @see BASE2
-     * @see BASE2_ABBREVIATED
+     * @see UnitsService#DEFAULT
+     * @see UnitsService#BASE10_ABBREVIATED
+     * @see UnitsService#BASE2
+     * @see UnitsService#BASE2_ABBREVIATED
      */
     public static ByteFormatter BASE10 = DEFAULT;
     /**
-     * A basic byte formatter which uses base10 (KB, MB) units.
-     * It automatically adapts to the locale (English, German).
-     * The unit is abbreviated out. Numbers are converted as soon as they reach the
-     * next unit. The precision defaults to 3, so numbers may be rounded
+     * A basic byte formatter which uses base10 (KB, MB) units. It automatically
+     * adapts to the locale (English, German). The unit is abbreviated out. Numbers
+     * are converted as soon as they reach the next unit. The precision defaults to
+     * 3, so numbers may be rounded
      * 
      * <p>
-     * Use {@link UnitsService.get().registerFormatter()} to register your own ByteFormatter.
-     * There is a default implementation available which you can parameterize at {@link DefaultByteFormatter}
+     * Use {@link UnitsService.get().registerFormatter()} to register your own
+     * ByteFormatter. There is a default implementation available which you can
+     * parameterize at {@link DefaultByteFormatter}
      * </p>
      * 
      * <ul>
-     * 	<li>986     --> 986 B / 986 B</li>
-     * 	<li>1024    --> 1.024 KB / 1,024 KB</li>
-     * 	<li>14368   --> 14.368 KB / 14,368 KB</li>
-     * 	<li>5743487 --> 5.743 MB / 5,743</li>
+     * <li>986 --> 986 B / 986 B</li>
+     * <li>1024 --> 1.024 KB / 1,024 KB</li>
+     * <li>14368 --> 14.368 KB / 14,368 KB</li>
+     * <li>5743487 --> 5.743 MB / 5,743</li>
      * </ul>
      * 
-     * @see UnitsService.registerFormatter
+     * @see UnitsService#registerFormatter()
      * @see DefaultByteFormatter
-     * @see DEFAULT
-     * @see BASE10
-     * @see BASE2
-     * @see BASE2_ABBREVIATED
+     * @see UnitsService#DEFAULT
+     * @see UnitsService#BASE10
+     * @see UnitsService#BASE2
+     * @see UnitsService#BASE2_ABBREVIATED
      */
-    public static ByteFormatter BASE10_ABBREVIATED =
-    		new DefaultByteFormatter.Builder().abbreviateUnit(true).build();
+    public static ByteFormatter BASE10_ABBREVIATED = new DefaultByteFormatter.Builder()
+            .abbreviateUnit(true).build();
     /**
-     * A basic byte formatter which uses written-out base2 (Kibibyte, Mebibyte) IEC units.
-     * It automatically adapts to the locale (English, German).
-     * The unit is abbreviated out. Numbers are converted as soon as they reach the
-     * next unit. The precision defaults to 3, so numbers may be rounded
+     * A basic byte formatter which uses written-out base2 (Kibibyte, Mebibyte) IEC
+     * units. It automatically adapts to the locale (English, German). The unit is
+     * abbreviated out. Numbers are converted as soon as they reach the next unit.
+     * The precision defaults to 3, so numbers may be rounded
      * 
      * <p>
-     * Use {@link UnitsService.get().registerFormatter()} to register your own ByteFormatter.
-     * There is a default implementation available which you can parameterize at {@link DefaultByteFormatter}
+     * Use {@link UnitsService.get().registerFormatter()} to register your own
+     * ByteFormatter. There is a default implementation available which you can
+     * parameterize at {@link DefaultByteFormatter}
      * </p>
      * 
      * <ul>
-     * 	<li>986     --> 986 bytes / 986 Bytes</li>
-     * 	<li>1024    --> 1 kibibyte / 1 Kibibyte</li>
-     * 	<li>143687  --> 14.031 kibibytes /  14,031 Kibibytes</li>
-     * 	<li>5743487 --> 5.743 mebibytes / 5,743 Mebibytes</li>
+     * <li>986 --> 986 bytes / 986 Bytes</li>
+     * <li>1024 --> 1 kibibyte / 1 Kibibyte</li>
+     * <li>143687 --> 14.031 kibibytes / 14,031 Kibibytes</li>
+     * <li>5743487 --> 5.743 mebibytes / 5,743 Mebibytes</li>
      * </ul>
      * 
-     * @see UnitsService.registerFormatter
+     * @see UnitsService#registerFormatter()
      * @see DefaultByteFormatter
-     * @see DEFAULT
-     * @see BASE10
-     * @see BASE10_ABBREVIATED
-     * @see BASE2_ABBREVIATED
+     * @see UnitsService#DEFAULT
+     * @see UnitsService#BASE10
+     * @see UnitsService#BASE10_ABBREVIATED
+     * @see UnitsService#BASE2_ABBREVIATED
      */
-    public static ByteFormatter BASE2 =
-    		new DefaultByteFormatter.Builder().asBase(BaseUnit.BASE_2).build();
+    public static ByteFormatter BASE2 = new DefaultByteFormatter.Builder().asBase(BaseUnit.BASE_2)
+            .build();
     /**
-     * A basic byte formatter which uses shortened base2 (KiB, MiB) IEC units.
-     * It automatically adapts to the locale (English, German).
-     * Numbers are converted as soon as they reach the next unit.
-     * The precision defaults to 3, so numbers may be rounded.
+     * A basic byte formatter which uses shortened base2 (KiB, MiB) IEC units. It
+     * automatically adapts to the locale (English, German). Numbers are converted
+     * as soon as they reach the next unit. The precision defaults to 3, so numbers
+     * may be rounded.
      * 
      * <p>
-     * Use {@link UnitsService.get().registerFormatter()} to register your own ByteFormatter.
-     * There is a default implementation available which you can parameterize at {@link DefaultByteFormatter}
+     * Use {@link UnitsService.get().registerFormatter()} to register your own
+     * ByteFormatter. There is a default implementation available which you can
+     * parameterize at {@link DefaultByteFormatter}
      * </p>
      * 
      * <ul>
-     * 	<li>986     --> 986 bytes / 986 Bytes</li>
-     * 	<li>1024    --> 1 KiB / 1 KiB</li>
-     * 	<li>143687  --> 14.031 KiB /  14,031 KiB</li>
-     * 	<li>5743487 --> 5.743 MiB / 5,743 MiB</li>
+     * <li>986 --> 986 bytes / 986 Bytes</li>
+     * <li>1024 --> 1 KiB / 1 KiB</li>
+     * <li>143687 --> 14.031 KiB / 14,031 KiB</li>
+     * <li>5743487 --> 5.743 MiB / 5,743 MiB</li>
      * </ul>
      * 
-     * @see UnitsService.registerFormatter
+     * @see UnitsService#registerFormatter()
      * @see DefaultByteFormatter
-     * @see DEFAULT
-     * @see BASE10
-     * @see BASE10_ABBREVIATED
-     * @see BASE2
+     * @see UnitsService#DEFAULT
+     * @see UnitsService#BASE10
+     * @see UnitsService#BASE10_ABBREVIATED
+     * @see UnitsService#BASE2
      */
-    public static ByteFormatter BASE2_ABBREVIATED =
-    		new DefaultByteFormatter.Builder().abbreviateUnit(true).asBase(BaseUnit.BASE_2).build();
-    
+    public static ByteFormatter BASE2_ABBREVIATED = new DefaultByteFormatter.Builder()
+            .abbreviateUnit(true).asBase(BaseUnit.BASE_2).build();
 
     /**
      * converts byte count to a human readable string Example output: SI BINARY
      * 
-     * 0: 0 B 0 B 27: 27 B 27 B 999: 999 B 999 B 1000: 1.0 KB 1000 B 1023: 1.0 KB 1023 B 1024: 1.0 KB 1.0 KiB 1728: 1.7
-     * KB 1.7 KiB 110592: 110.6 KB 108.0 KiB 7077888: 7.1 MB 6.8 MiB 452984832: 453.0 MB 432.0 MiB 28991029248: 29.0 GB
-     * 27.0 GiB 1855425871872: 1.9 TB 1.7 TiB 9223372036854775807: 9.2 EB 8.0 EiB (Long.MAX_VALUE)
+     * 0: 0 B 0 B 27: 27 B 27 B 999: 999 B 999 B 1000: 1.0 KB 1000 B 1023: 1.0 KB
+     * 1023 B 1024: 1.0 KB 1.0 KiB 1728: 1.7 KB 1.7 KiB 110592: 110.6 KB 108.0 KiB
+     * 7077888: 7.1 MB 6.8 MiB 452984832: 453.0 MB 432.0 MiB 28991029248: 29.0 GB
+     * 27.0 GiB 1855425871872: 1.9 TB 1.7 TiB 9223372036854775807: 9.2 EB 8.0 EiB
+     * (Long.MAX_VALUE)
      * 
      * @return byte count including units as string
+     * 
+     * @deprecated Will soon be replaced by
      */
-
     public static String humanReadableByteCount(long bytes, boolean si) {
         int unit = si ? 1000 : 1024;
         if (bytes < unit)
@@ -393,12 +435,5 @@ public class UnitsService {
         String pre = (si ? "kMGTPE" : "KMGTPE").charAt(exp - 1) + (si ? "" : "i"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
         return String.format("%.1f %sB", bytes / Math.pow(unit, exp), pre); //$NON-NLS-1$
     }
-    
-    public static void main(String[] args) {
-    	ByteFormatter myByteFormatter = new DefaultByteFormatter.Builder().build();
-    	System.out.println(myByteFormatter.format(983));
-    }
 
-    
-    
 }

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/UnitsService.java
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/UnitsService.java
@@ -318,7 +318,7 @@ public class UnitsService {
      * @see BASE2_ABBREVIATED
      */
     public static ByteFormatter BASE10_ABBREVIATED =
-    		new DefaultByteFormatter.Builder().abbreviateUnit(false).build();
+    		new DefaultByteFormatter.Builder().abbreviateUnit(true).build();
     /**
      * A basic byte formatter which uses written-out base2 (Kibibyte, Mebibyte) IEC units.
      * It automatically adapts to the locale (English, German).
@@ -372,7 +372,7 @@ public class UnitsService {
      * @see BASE2
      */
     public static ByteFormatter BASE2_ABBREVIATED =
-    		new DefaultByteFormatter.Builder().abbreviateUnit(false).asBase(BaseUnit.BASE_2).build();
+    		new DefaultByteFormatter.Builder().abbreviateUnit(true).asBase(BaseUnit.BASE_2).build();
     
 
     /**

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/messages.properties
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/messages.properties
@@ -1,0 +1,23 @@
+LocaleThousandSeparator=,
+LocaleCommaSeparator=.
+unitByte=byte
+
+# Base 10 byte count
+unitKiloByte=kilobyte
+unitMegaByte=megabyte
+unitGigaByte=gigabyte
+unitTeraByte=terabyte
+unitPetaByte=petabyte
+unitExaByte=exabyte
+unitZettaByte=zettabyte
+unitYottaByte=yottabyte
+
+# Base 2 IEC byte count
+unitKibiByte=kibibyte
+unitMebiByte=mebibyte
+unitGibiByte=gibibyte
+unitTebiByte=tebibyte
+unitPebiByte=pebibyte
+unitExbiByte=exbibyte
+unitZebibyte=zebibyte
+unitYobiByte=yobibyte

--- a/org.jcryptool.core.util/src/org/jcryptool/core/util/units/messages_de.properties
+++ b/org.jcryptool.core.util/src/org/jcryptool/core/util/units/messages_de.properties
@@ -1,0 +1,23 @@
+LocaleThousandSeparator=\u2009
+LocaleCommaSeparator=,
+unitByte=Byte
+
+# Base 10 byte count
+unitKiloByte=Kilobyte
+unitMegaByte=Megabyte
+unitGigaByte=Gigabyte
+unitTeraByte=Terabyte
+unitPetaByte=Petabyte
+unitExaByte=Exabyte
+unitZettaByte=Zettabyte
+unitYottaByte=Yottabyte
+
+# Base 2 IEC byte count
+unitKibiByte=Kibibyte
+unitMebiByte=Mebibyte
+unitGibiByte=Gibibyte
+unitTebiByte=Tebibyte
+unitPebiByte=Pebibyte
+unitExbiByte=Exbibyte
+unitZebibyte=Zebibyte
+unitYobiByte=Yobibyte


### PR DESCRIPTION
### Issue: https://github.com/jcryptool/crypto/issues/350 

# Add Byteformatting provider

This PR adds byte functionality to the UnitsService class in `org.jcryptool.core.util.units.UnitsService.java`, which will replace the old `humanReadableByteCount()` which is marked as deprecated.

## Why?
This feature is required quite often in JCrypTool, so I wanted to provide a proper one which can be adjusted to plug-in needs.

## Features

A feature overview can be found in this PDF I created from a Jupyter showcase.

[jct_byteformat_jpype_showcase.pdf](https://github.com/jcryptool/core/files/5937389/jct_byteformat_jpype_showcase.pdf)
