### PR TITLE
Language chooser and Linux post-languagesetting restart

### DIFF
--- a/org.jcryptool.core/plugin.xml
+++ b/org.jcryptool.core/plugin.xml
@@ -280,9 +280,6 @@
    <extension point="org.jcryptool.core.platformLanguage">
       <language languageCode="de_DE" languageDescription="%language.languageGerman"/>
    </extension>
-   <extension point="org.jcryptool.core.platformLanguage">
-      <language languageCode="fr_FR" languageDescription="%language.languageFrench"/>
-   </extension>
 
    <extension point="org.eclipse.e4.ui.css.swt.theme">
       <theme basestylesheeturi="css/jcryptool.css" id="org.jcryptool.themes.default" label="Default Theme"/>

--- a/org.jcryptool.core/src/org/jcryptool/core/Application.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/Application.java
@@ -202,7 +202,7 @@ public class Application implements IApplication {
 		List<String> vmArg = getCommandLinePartFromString(System.getProperty("eclipse.vm"));
 		if (vmArg.isEmpty()) {
 			System.err.println(
-					"could not set eclipse.exitdata properly; eclipse.vm is not set. This is expected when the application is run in developer mode; relaunch manually.");
+					"When restarting the application, could not set eclipse.exitdata properly; eclipse.vm is not set. This is expected when the application is run in developer mode. Please relaunch manually.");
 			return;
 		}
 		List<String> vmArgsArg = getCommandLinePartFromString(System.getProperty("eclipse.vmargs"));

--- a/org.jcryptool.core/src/org/jcryptool/core/Application.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/Application.java
@@ -49,15 +49,8 @@ import org.osgi.framework.FrameworkUtil;
  * This class controls all aspects of the application's execution.
  * 
  * @author Dominik Schadow
- * @version 1.0.0
- */
-/**
- * @author snuc
- *
- */
-/**
- * @author snuc
- *
+ * @author Simon Leischnig
+ * @version 1.0.3.qualifier
  */
 public class Application implements IApplication {
 
@@ -105,7 +98,7 @@ public class Application implements IApplication {
 				}
 				LanguageChooser chooser = new LanguageChooser(shell);
 				int retcode = chooser.open(); // actually, we have to restart, so we ignore the return code. Also, there
-												// is no cancel button.
+							    			  // is no cancel button.
 
 				Function<List<String>, List<String>> inifileFilter = createLanguageRewriteInifileFilter(chooser.nl);
 				applyFilterToInifile(inifileFilter);
@@ -173,11 +166,11 @@ public class Application implements IApplication {
 		}
 	}
 
-	private static List<String> getCommandLinePartFromString(String linedelimitedArgs) {
-		if (linedelimitedArgs == null) {
+	private static List<String> getCommandLinePartFromString(String lineDelimitedArgs) {
+		if (lineDelimitedArgs == null) {
 			return new LinkedList<String>();
 		}
-		return linedelimitedArgs.lines().filter(line -> !line.isEmpty()).collect(Collectors.toList());
+		return lineDelimitedArgs.lines().filter(line -> !line.isEmpty()).collect(Collectors.toList());
 	}
 
 	/**
@@ -195,8 +188,8 @@ public class Application implements IApplication {
 			Function<List<String>, List<String>> filter) {
 		List<String> vmArg = getCommandLinePartFromString(System.getProperty("eclipse.vm"));
 		if (vmArg.isEmpty()) {
-			System.err.println(
-					"When restarting the application, could not set eclipse.exitdata properly; eclipse.vm is not set. This is expected when the application is run in developer mode. Please relaunch manually.");
+			LogUtil.logError("When restarting the application, could not set eclipse.exitdata properly; eclipse.vm is not set. "
+					+ "This is expected when the application is run in developer mode. Please relaunch manually.");
 			return;
 		}
 		List<String> vmArgsArg = getCommandLinePartFromString(System.getProperty("eclipse.vmargs"));
@@ -205,11 +198,14 @@ public class Application implements IApplication {
 		reconstructedCmdline.addAll(vmArg);
 		reconstructedCmdline.addAll(vmArgsArg);
 		reconstructedCmdline.addAll(commandArgs);
-		List<String> filteredCommandline = filter.apply(reconstructedCmdline); // filtering is necessary _exactly_ here, not after next two lines. TODO maybe: leave out vmargs out of filtering process (less power, but less errorprone also)
-		filteredCommandline.add("-vmargs"); // this is somehow necessary to tell the next instance what the VM arguments were...
-		filteredCommandline.addAll(vmArgsArg); // see above line
+
+		List<String> filteredCommandline = filter.apply(reconstructedCmdline); 	// filtering is necessary _exactly_ here, not after next two lines. 
+																				// TODO maybe: leave out vmargs out of filtering process (less power, but less errorprone also)
+		filteredCommandline.add("-vmargs"); 									// this is somehow necessary to tell the next instance what the VM arguments were...
+		filteredCommandline.addAll(vmArgsArg); 									// see above line
+
 		String resultargs = filteredCommandline.stream().collect(Collectors.joining("\n"));
-		System.err.println(String.format(
+		LogUtil.logInfo(String.format(
 				"Restarting the application with filtered commandline, now stored in eclipse.exitdata: %s",
 				resultargs));
 		System.setProperty("eclipse.exitdata", resultargs);

--- a/org.jcryptool.core/src/org/jcryptool/core/Application.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/Application.java
@@ -17,15 +17,19 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Locale;
 import java.util.Properties;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
 import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.osgi.service.environment.EnvironmentInfo;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.MessageBox;
@@ -43,9 +47,26 @@ import org.jcryptool.core.logging.utils.LogUtil;
  * @author Dominik Schadow
  * @version 1.0.0
  */
+/**
+ * @author snuc
+ *
+ */
+/**
+ * @author snuc
+ *
+ */
 public class Application implements IApplication {
 
-    /*
+	/**
+	 * If this field is set to something else than null, the application will consider 
+	 * the exit code {@link IApplication#EXIT_RESTART} as {@link IApplication#EXIT_RELAUNCH}
+	 * and set the exitdata property accordingly. This is e.g. used to filter out language 
+	 * switches a.k.a. `-nl {language}`. Since other important switches like `-data {workspace}` may
+	 * be present, we can't throw out every command line parameter — hence this filtering approach.
+	 */
+    private static Function<List<String>, List<String>> restart_cmdlinefilter = null;
+
+	/*
      * (non-Javadoc)
      * @see org.eclipse.equinox.app.IApplication#start(org.eclipse.equinox.app.IApplicationContext)
      */
@@ -73,28 +94,25 @@ public class Application implements IApplication {
 					shell = new Shell();
 				}
 				LanguageChooser chooser = new LanguageChooser(shell);
-				int retcode = chooser.open();
-				restartWithChangedLanguage(chooser.nl, false);
+				int retcode = chooser.open(); // actually, we have to restart, so we ignore the return code. Also, there is no cancel button.
+
+				Function<List<String>, List<String>> inifileFilter = createLanguageRewriteInifileFilter(chooser.nl);
+				applyFilterToInifile(inifileFilter);
+
+				// this filters the cmdline arguments so that they don't change the language back
+				Function<List<String>, List<String>> cmdlineFilter = createCmdlineRewriteRemoveLanguagespecFilter();
+				filterCommandlineArgsForRelaunch(context, cmdlineFilter);
+				// this is a low-level restart (can't use workbench here)
+				return IApplication.EXIT_RELAUNCH;
         	}
         } catch (Exception e) {
             LogUtil.logError(CorePlugin.PLUGIN_ID, e);
         }
         
-        Display display = PlatformUI.createDisplay();
-        try {
-            int returnCode = PlatformUI.createAndRunWorkbench(display, new ApplicationWorkbenchAdvisor());
-            if (returnCode == PlatformUI.RETURN_RESTART) {
-                return IApplication.EXIT_RESTART;
-            } else {
-                return IApplication.EXIT_OK;
-            }
-        } finally {
-            display.dispose();
-        }
-
+        return startApplication(context);
     }
-
-    /*
+    
+	/*
      * (non-Javadoc)
      * @see org.eclipse.equinox.app.IApplication#stop()
      */
@@ -116,14 +134,80 @@ public class Application implements IApplication {
     }
 
 
+
     /**
-     * Sets the language in the <b>JCrypTool.ini</b>. This file is located in a different folder on Mac OS X.
-     * 
-     * @param language
-     * @throws IOException 
-     * @throws Exception
+     * Starts the GUI and controls the application's return code behavior.
+     * @param context 
+     * @return the exit code; see e.g. {@link IApplication#EXIT_RELAUNCH}
      */
-    private static void setLanguage(String language) throws IOException {
+    private Object startApplication(IApplicationContext context) {
+        Display display = PlatformUI.createDisplay();
+        // the application return code behavior
+        try {
+            int returnCode = PlatformUI.createAndRunWorkbench(display, new ApplicationWorkbenchAdvisor());
+            if (returnCode == PlatformUI.RETURN_RESTART) {
+            	if (restart_cmdlinefilter != null) {
+            		filterCommandlineArgsForRelaunch(context, restart_cmdlinefilter);
+            		return IApplication.EXIT_RELAUNCH;
+				} else {
+					return IApplication.EXIT_RESTART;
+				}
+            } else {
+                return IApplication.EXIT_OK;
+            }
+        } finally {
+            display.dispose();
+        }
+	}
+
+    /**
+     * Filters commandlineargs for a relaunch. Only applicable within the {@link #start(IApplicationContext)} or {@link #startApplication(IApplicationContext)} functions.
+     * If this behavior is desired elsewhere, see {@link Application#restart_cmdlinefilter} and use Workbench.restart().
+     * 
+     * @param context the application context
+     * @param filter the filter to use on the commandline args
+     * @return
+     */
+    private static void filterCommandlineArgsForRelaunch(IApplicationContext context, Function<List<String>, List<String>> filter) {
+    	// TODO: these do not include the launcher or the equinox runnables!! Find `EnvironmentInfo` seems the way to proceed.
+    	List<String> args = Arrays.asList(Platform.getCommandLineArgs());
+    	List<String> filteredArgs = filter.apply(args);
+
+		// TODO: escape whitespace? e.g. for -data ... paths?
+    	String resultargs = filteredArgs.stream().collect(Collectors.joining(" "));
+		// TODO: test if that actually has the desired effect
+    	System.setProperty("eclipse.exitdata", resultargs);
+	}
+
+    /**
+     * This restarts the application. May only be called when the workbench has been started yet! Else, 
+     * see the code pertaining to {@link Application#restart_cmdlinefilter} and {@link #startApplication(IApplicationContext)}
+     * 
+     * @param ask whether a dialog box should be opened that asks whether the action should be performed.
+     * @param cmdlineFilter a filter that is applied to the commandline arguments
+     */
+	private static void restartAppWithCommandlinefilter(boolean ask, Function<List<String>, List<String>> cmdlineFilter) {
+		boolean doRestart = false;
+		if (ask) {
+			MessageBox mbox = new MessageBox(Display.getDefault().getActiveShell(), SWT.ICON_QUESTION | SWT.YES | SWT.NO);
+			mbox.setText(org.jcryptool.core.preferences.pages.Messages.MessageTitleRestart);
+			mbox.setMessage(org.jcryptool.core.preferences.pages.Messages.MessageRestart);
+			if (mbox.open() == SWT.YES) {
+				LogUtil.logInfo(org.jcryptool.core.preferences.pages.Messages.MessageLogRestart);
+				doRestart = true;
+			}
+		} else {
+			doRestart = true;
+		}
+		
+		if (doRestart) {
+			// this instructs the application to filter commandline arguments and relaunching instead of restarting
+			Application.restart_cmdlinefilter = cmdlineFilter;
+			PlatformUI.getWorkbench().restart();
+		}
+    }
+    
+	private static void applyFilterToInifile(Function<List<String>, List<String>> filter) throws IOException {
         String path = Platform.getInstallLocation().getURL().toExternalForm();
         String fileNameOrg = Platform.getProduct().getName() + ".ini"; //$NON-NLS-1$
         String fileNameBak = fileNameOrg + ".bak"; //$NON-NLS-1$
@@ -143,54 +227,80 @@ public class Application implements IApplication {
         fileOrg.renameTo(fileBak);
         BufferedReader in = new BufferedReader(new FileReader(fileBak));
         BufferedWriter out = new BufferedWriter(new FileWriter(fileOrg));
-        var lines = in.lines().collect(Collectors.toList());
-        in.close();
-        var linesOut = new LinkedList<String>();
-        boolean previousWasNLFlag = false;
-        for(String line: lines) {
-        	boolean isNlFlag = line.trim().equals("-nl");
-        	// first, keep all lines that don't have to do with language
-        	if (isNlFlag || previousWasNLFlag) {
-				linesOut.add(line); // TODO: includes linebreak?
-			}
-        	// keep track of state
-			if (isNlFlag) {
-        		previousWasNLFlag = true;
-        	} else {
-        		previousWasNLFlag = false;
-			}
-        }
-        linesOut.add("-nl");
-        linesOut.add(language);
+
+        // the filtering step
+        List<String> lines = in.lines().collect(Collectors.toList());
+		var linesOut = filter.apply(lines);
+
 		for(String outLine : linesOut) {
         	out.write(outLine + "\n");
         }
+
 		out.flush();
 		out.close();
-        
-    }
-
-    private static void restartAppWithInifileReload(boolean ask) {
-		boolean doRestart = false;
-		if (ask) {
-			MessageBox mbox = new MessageBox(Display.getDefault().getActiveShell(), SWT.ICON_QUESTION | SWT.YES | SWT.NO);
-			mbox.setText(org.jcryptool.core.preferences.pages.Messages.MessageTitleRestart);
-			mbox.setMessage(org.jcryptool.core.preferences.pages.Messages.MessageRestart);
-			if (mbox.open() == SWT.YES) {
-				LogUtil.logInfo(org.jcryptool.core.preferences.pages.Messages.MessageLogRestart);
-				doRestart = true;
-			}
-		} else {
-			doRestart = true;
-		}
-		
-		if (doRestart) {
-			PlatformUI.getWorkbench().restart();
-		}
-    }
-    
-	public static void restartWithChangedLanguage(String language, boolean ask) throws IOException {
-		setLanguage(language);
-		restartAppWithInifileReload(ask);
+        in.close();
 	}
+	
+	/**
+	 * rewrites a commandline so that it does not include -nl flags
+	 * @param newLanguage the new language (e.g. "en")
+	 * @return the new commandline as list
+	 */
+	private static Function<List<String>, List<String>> createLanguageRewriteInifileFilter(String newLanguage) {
+		return (List<String> in) -> {
+			var linesOut = new LinkedList<String>();
+			boolean previousWasNLFlag = false;
+			for(String line: in) {
+				boolean isNlFlag = line.trim().equals("-nl");
+				// first, keep all lines that don't have to do with language
+				if (! (isNlFlag || previousWasNLFlag)) {
+					linesOut.add(line);
+				}
+				// keep track of state
+				if (isNlFlag) {
+					previousWasNLFlag = true;
+				} else {
+					previousWasNLFlag = false;
+				}
+			}
+			// add the new language flags at the end
+			linesOut.add("-nl");
+			linesOut.add(newLanguage);
+			return linesOut;
+		};
+	}
+
+	/**
+	 * rewrites a commandline so that it does not include -nl flags
+	 * 
+	 * @return the new commandline as list
+	 */
+	private static Function<List<String>, List<String>> createCmdlineRewriteRemoveLanguagespecFilter() {
+		return (List<String> in) -> {
+			var linesOut = new LinkedList<String>();
+			boolean previousWasNLFlag = false;
+			for(String line: in) {
+				boolean isNlFlag = line.trim().equals("-nl");
+				// first, keep all lines that don't have to do with language
+				if (! (isNlFlag || previousWasNLFlag)) {
+					linesOut.add(line);
+				}
+				// keep track of state
+				if (isNlFlag) {
+					previousWasNLFlag = true;
+				} else {
+					previousWasNLFlag = false;
+				}
+			}
+			return linesOut;
+		};
+	}
+	
+	public static void restartWithChangedLanguage(String language, boolean ask) throws IOException {
+		Function<List<String>, List<String>> cmdlineFilter = createCmdlineRewriteRemoveLanguagespecFilter();
+		Function<List<String>, List<String>> inifileFilter = createLanguageRewriteInifileFilter(language);
+		applyFilterToInifile(inifileFilter);
+		restartAppWithCommandlinefilter(ask, cmdlineFilter);
+	}
+
 }

--- a/org.jcryptool.core/src/org/jcryptool/core/Application.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/Application.java
@@ -298,32 +298,18 @@ public class Application implements IApplication {
 	}
 
 	/**
-	 * rewrites a commandline so that it does not include -nl flags
+	 * rewrites a commandline so that it does not include -nl flags. Then, `-nl`, `{newLanguage}` are appended to effectively overwrite the language.
 	 * 
 	 * @param newLanguage the new language (e.g. "en")
 	 * @return the new commandline as list
 	 */
 	private static Function<List<String>, List<String>> createLanguageRewriteInifileFilter(String newLanguage) {
 		return (List<String> in) -> {
-			var linesOut = new LinkedList<String>();
-			boolean previousWasNLFlag = false;
-			for (String line : in) {
-				boolean isNlFlag = line.trim().equals("-nl");
-				// first, keep all lines that don't have to do with language
-				if (!(isNlFlag || previousWasNLFlag)) {
-					linesOut.add(line);
-				}
-				// keep track of state
-				if (isNlFlag) {
-					previousWasNLFlag = true;
-				} else {
-					previousWasNLFlag = false;
-				}
-			}
-			// add the new language flags at the end
-			linesOut.add("-nl");
-			linesOut.add(newLanguage);
-			return linesOut;
+			return createCmdlineRewriteRemoveLanguagespecFilter().andThen(linesAfter -> {
+				linesAfter.add("-nl");
+				linesAfter.add(newLanguage);
+				return linesAfter;
+			}).apply(in);
 		};
 	}
 

--- a/org.jcryptool.core/src/org/jcryptool/core/Application.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/Application.java
@@ -9,14 +9,33 @@
 // -----END DISCLAIMER-----
 package org.jcryptool.core;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.LinkedList;
 import java.util.Locale;
+import java.util.Properties;
+import java.util.stream.Collectors;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.MessageBox;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.application.WorkbenchAdvisor;
 import org.jcryptool.core.logging.utils.LogUtil;
+
+
 
 /**
  * This class controls all aspects of the application's execution.
@@ -33,15 +52,30 @@ public class Application implements IApplication {
     @Override
 	public Object start(IApplicationContext context) throws Exception {
         try {
-        	// Set English as default language if the operating system language is neither 
-        	// German, English or French.
-        	if (!Locale.getDefault().getLanguage().equals("de") &&
-        			!Locale.getDefault().getLanguage().equals("en") &&
-        			!Locale.getDefault().getLanguage().equals("fr")) {
-              System.setProperty("osgi.nl", "en"); // fixes Platform.getNL()
-              Locale.setDefault(Locale.ENGLISH);
-        	}
+        	// Set English as default language if the operating system language is neither German, English
         	System.setProperty("file.encoding", "UTF-8");
+        	if (!Locale.getDefault().getLanguage().equals("de") &&
+        			!Locale.getDefault().getLanguage().equals("en")) {
+
+				Shell shell = null;
+        		try {
+        			IWorkbench wb = PlatformUI.getWorkbench();
+					if (wb != null) {
+						var windows = wb.getWorkbenchWindows();
+						if (windows.length > 0) {
+							shell = windows[0].getShell();
+						}
+					}
+        		} catch (Exception e) {
+					// do nothing, this is expected...
+				}
+				if (shell == null) {
+					shell = new Shell();
+				}
+				LanguageChooser chooser = new LanguageChooser(shell);
+				int retcode = chooser.open();
+				restartWithChangedLanguage(chooser.nl, false);
+        	}
         } catch (Exception e) {
             LogUtil.logError(CorePlugin.PLUGIN_ID, e);
         }
@@ -80,4 +114,83 @@ public class Application implements IApplication {
             }
         });
     }
+
+
+    /**
+     * Sets the language in the <b>JCrypTool.ini</b>. This file is located in a different folder on Mac OS X.
+     * 
+     * @param language
+     * @throws IOException 
+     * @throws Exception
+     */
+    private static void setLanguage(String language) throws IOException {
+        String path = Platform.getInstallLocation().getURL().toExternalForm();
+        String fileNameOrg = Platform.getProduct().getName() + ".ini"; //$NON-NLS-1$
+        String fileNameBak = fileNameOrg + ".bak"; //$NON-NLS-1$
+
+        if ("macosx".equalsIgnoreCase(Platform.getOS())) { //$NON-NLS-1$
+            path += "JCrypTool.app/Contents/MacOS/"; //$NON-NLS-1$
+        }
+        File fileOrg = new File(new URL(path + fileNameOrg).getFile());
+        File fileBak = new File(new URL(path + fileNameBak).getFile());
+        if (fileBak.exists()) {
+            fileBak.delete();
+        }
+        // solve the problem that if the .ini file doesn't exist yet, it can't be created
+        if(!fileOrg.exists()) {
+        	fileOrg.createNewFile();
+        }
+        fileOrg.renameTo(fileBak);
+        BufferedReader in = new BufferedReader(new FileReader(fileBak));
+        BufferedWriter out = new BufferedWriter(new FileWriter(fileOrg));
+        var lines = in.lines().collect(Collectors.toList());
+        in.close();
+        var linesOut = new LinkedList<String>();
+        boolean previousWasNLFlag = false;
+        for(String line: lines) {
+        	boolean isNlFlag = line.trim().equals("-nl");
+        	// first, keep all lines that don't have to do with language
+        	if (isNlFlag || previousWasNLFlag) {
+				linesOut.add(line); // TODO: includes linebreak?
+			}
+        	// keep track of state
+			if (isNlFlag) {
+        		previousWasNLFlag = true;
+        	} else {
+        		previousWasNLFlag = false;
+			}
+        }
+        linesOut.add("-nl");
+        linesOut.add(language);
+		for(String outLine : linesOut) {
+        	out.write(outLine + "\n");
+        }
+		out.flush();
+		out.close();
+        
+    }
+
+    private static void restartAppWithInifileReload(boolean ask) {
+		boolean doRestart = false;
+		if (ask) {
+			MessageBox mbox = new MessageBox(Display.getDefault().getActiveShell(), SWT.ICON_QUESTION | SWT.YES | SWT.NO);
+			mbox.setText(org.jcryptool.core.preferences.pages.Messages.MessageTitleRestart);
+			mbox.setMessage(org.jcryptool.core.preferences.pages.Messages.MessageRestart);
+			if (mbox.open() == SWT.YES) {
+				LogUtil.logInfo(org.jcryptool.core.preferences.pages.Messages.MessageLogRestart);
+				doRestart = true;
+			}
+		} else {
+			doRestart = true;
+		}
+		
+		if (doRestart) {
+			PlatformUI.getWorkbench().restart();
+		}
+    }
+    
+	public static void restartWithChangedLanguage(String language, boolean ask) throws IOException {
+		setLanguage(language);
+		restartAppWithInifileReload(ask);
+	}
 }

--- a/org.jcryptool.core/src/org/jcryptool/core/Application.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/Application.java
@@ -40,6 +40,7 @@ import org.eclipse.ui.application.WorkbenchAdvisor;
 import org.jcryptool.core.logging.utils.LogUtil;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceReference;
+import org.osgi.framework.FrameworkUtil;
 
 
 
@@ -76,6 +77,14 @@ public class Application implements IApplication {
     @Override
 	public Object start(IApplicationContext context) throws Exception {
     	this.applicationContext = context;
+    	Properties props = System.getProperties();
+    	System.out.println("0:" + props.entrySet().stream().map(e -> String.format("%s->%s", e.getKey(), e.getValue())).collect(Collectors.joining("\n")));
+    	System.out.println("1: " + System.getProperty("vmargs"));
+    	System.out.println("2eclipse.vm=: " + System.getProperty("eclipse.vm"));
+    	System.out.println("2eclipse.vmargs=: " + System.getProperty("eclipse.vmargs"));
+    	System.out.println("2eclipse.commands=: " + System.getProperty("eclipse.commands"));
+    	String[] bla = (String[]) context.getArguments().get(IApplicationContext.APPLICATION_ARGS);
+    	System.out.println("3: " + Arrays.asList(bla));
         try {
         	// Set English as default language if the operating system language is neither German, English
         	System.setProperty("file.encoding", "UTF-8");
@@ -117,6 +126,7 @@ public class Application implements IApplication {
     }
 
 	private BundleContext getBundleContext() {
+//		return getOtherBundleContext(); // this seems to be another way to get it
 		return this.applicationContext.getBrandingBundle().getBundleContext();
 	}
     
@@ -316,7 +326,13 @@ public class Application implements IApplication {
 
 	private String[] getFrameworkArguments(BundleContext bc) {
 		EnvironmentInfo envInfo = getEnvironmentInfo(bc);
-		return (envInfo.getFrameworkArgs());
+		var a1 = envInfo.getCommandLineArgs();
+		var a2 = envInfo.getFrameworkArgs();
+		var a3 = envInfo.getNonFrameworkArgs();
+		System.out.println(String.format("getCommandLineArgs: %s", Arrays.asList(a1)));
+		System.out.println(String.format("getFrameworkArgs: %s", Arrays.asList(a2)));
+		System.out.println(String.format("getNonFrameworkArgs: %s", Arrays.asList(a3)));
+		return a1;
 	}
 
 	private static EnvironmentInfo getEnvironmentInfo(BundleContext bc) {
@@ -330,6 +346,12 @@ public class Application implements IApplication {
 		}
 		bc.ungetService(infoRef);
 		return envInfo;
+	}
+
+
+	public BundleContext getOtherBundleContext() {
+		BundleContext bundleContext = FrameworkUtil.getBundle(this.getClass()).getBundleContext();
+		return bundleContext;
 	}
 
 }

--- a/org.jcryptool.core/src/org/jcryptool/core/Application.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/Application.java
@@ -341,13 +341,8 @@ public class Application implements IApplication {
 	 * @throws IOException
 	 */
 	public static void restartWithChangedLanguage(String language, boolean ask) throws IOException {
-//		Function<List<String>, List<String>> cmdlineFilter = createCmdlineRewriteRemoveLanguagespecFilter(); // this would not specify a language on the command line; seems to not work on Linux/Ubuntu20.04
-		Function<List<String>, List<String>> cmdlineFilter = createLanguageRewriteInifileFilter(language); // this uses
-																											// the same
-																											// mechanism
-																											// as for
-																											// the ini
-																											// file
+//		Function<List<String>, List<String>> cmdlineFilter = createCmdlineRewriteRemoveLanguagespecFilter(); // this would not specify a language on the command line; seems to not work on Linux/Ubuntu20.04 as the ini file is not automatically re-read on restart there.
+		Function<List<String>, List<String>> cmdlineFilter = createLanguageRewriteInifileFilter(language);   // this uses  the same  mechanism  as for  the ini  file
 		Function<List<String>, List<String>> inifileFilter = createLanguageRewriteInifileFilter(language);
 		applyFilterToInifile(inifileFilter);
 		restartAppWithCommandlinefilter(ask, cmdlineFilter);

--- a/org.jcryptool.core/src/org/jcryptool/core/ApplicationWorkbenchAdvisor.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/ApplicationWorkbenchAdvisor.java
@@ -68,6 +68,13 @@ public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor {
             }
         }
     }
+    
+    @Override
+    public void preStartup() {
+    	// TODO Auto-generated method stub
+    	System.out.println("HELLO");
+    	super.preStartup();
+    }
 
     /**
      * @see org.eclipse.ui.application.WorkbenchAdvisor#preShutdown()

--- a/org.jcryptool.core/src/org/jcryptool/core/ApplicationWorkbenchAdvisor.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/ApplicationWorkbenchAdvisor.java
@@ -71,7 +71,6 @@ public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor {
     
     @Override
     public void preStartup() {
-    	// TODO Auto-generated method stub
     	super.preStartup();
     }
 

--- a/org.jcryptool.core/src/org/jcryptool/core/ApplicationWorkbenchAdvisor.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/ApplicationWorkbenchAdvisor.java
@@ -72,7 +72,6 @@ public class ApplicationWorkbenchAdvisor extends WorkbenchAdvisor {
     @Override
     public void preStartup() {
     	// TODO Auto-generated method stub
-    	System.out.println("HELLO");
     	super.preStartup();
     }
 

--- a/org.jcryptool.core/src/org/jcryptool/core/LanguageChooser.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/LanguageChooser.java
@@ -19,6 +19,7 @@ public class LanguageChooser extends Dialog {
 	public Button btnEnglish;
 	public Button btnGerman;
 	protected String nl = "en";
+	private Label lblNewLabel2;
 
 	/**
 	 * Create the dialog.
@@ -36,11 +37,16 @@ public class LanguageChooser extends Dialog {
 	protected Control createDialogArea(Composite parent) {
 		Composite container = (Composite) super.createDialogArea(parent);
 		container.setLayout(new GridLayout(1, false));
+		getShell().setText("Choose your Language");
 		
+		lblNewLabel = new Label(container, SWT.WRAP);
+		lblNewLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+		lblNewLabel.setText("JCrypTool is available only in English and German. Which language do you prefer?\nYou may change the Language later in 'Window -> Settings -> JCT General'.");
+
+		lblNewLabel2 = new Label(container, SWT.WRAP);
+		lblNewLabel2.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+		lblNewLabel2.setText("JCrypTool ist nur auf Englisch und Deutsch verfügbar. Welche Sprache möchten Sie nutzen? \nSie können die Sprache später ändern im Menü 'Fenster -> Preferences -> JCT Allgemein'.");
 		
-		lblNewLabel = new Label(container, SWT.NONE);
-		lblNewLabel.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false, 1, 1));
-		lblNewLabel.setText("JCrypTool is only available in English and German; which language do you prefer?");
 		
 		btnEnglish = new Button(container, SWT.RADIO);
 		btnEnglish.addSelectionListener(new SelectionAdapter() {
@@ -51,7 +57,7 @@ public class LanguageChooser extends Dialog {
 			}
 		});
 		btnEnglish.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-		btnEnglish.setText("Restart JCrypTool in English");
+		btnEnglish.setText("Start JCrypTool in English");
 		btnEnglish.setSelection(true);
 		
 		btnGerman = new Button(container, SWT.RADIO);
@@ -82,12 +88,12 @@ public class LanguageChooser extends Dialog {
 //		createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, false);
 	}
 
-	/**
-	 * Return the initial size of the dialog.
-	 */
-	@Override
-	protected Point getInitialSize() {
-		return new Point(600, 300);
-	}
-
+//	/**
+//	 * Return the initial size of the dialog.
+//	 */
+//	@Override
+//	protected Point getInitialSize() {
+//		return new Point(600, 300);
+//	}
+	
 }

--- a/org.jcryptool.core/src/org/jcryptool/core/LanguageChooser.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/LanguageChooser.java
@@ -1,0 +1,93 @@
+package org.jcryptool.core;
+
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+
+public class LanguageChooser extends Dialog {
+	public Label lblNewLabel;
+	public Button btnEnglish;
+	public Button btnGerman;
+	protected String nl = "en";
+
+	/**
+	 * Create the dialog.
+	 * @param parentShell
+	 */
+	public LanguageChooser(Shell parentShell) {
+		super(parentShell);
+	}
+
+	/**
+	 * Create contents of the dialog.
+	 * @param parent
+	 */
+	@Override
+	protected Control createDialogArea(Composite parent) {
+		Composite container = (Composite) super.createDialogArea(parent);
+		container.setLayout(new GridLayout(1, false));
+		
+		
+		lblNewLabel = new Label(container, SWT.NONE);
+		lblNewLabel.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false, 1, 1));
+		lblNewLabel.setText("JCrypTool is only available in English and German; which language do you prefer?");
+		
+		btnEnglish = new Button(container, SWT.RADIO);
+		btnEnglish.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				LanguageChooser.this.nl="en";
+				LanguageChooser.this.updateDialog();
+			}
+		});
+		btnEnglish.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+		btnEnglish.setText("Restart JCrypTool in English");
+		btnEnglish.setSelection(true);
+		
+		btnGerman = new Button(container, SWT.RADIO);
+		btnGerman.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
+		btnGerman.setText("Starte JCrypTool auf Deutsch");
+		btnGerman.addSelectionListener(new SelectionAdapter() {
+			@Override
+			public void widgetSelected(SelectionEvent e) {
+				LanguageChooser.this.nl="de";
+				LanguageChooser.this.updateDialog();
+			}
+		});
+
+		return container;
+	}
+
+	protected void updateDialog() {
+		// nothing to do for now; any state is valid...
+	}
+
+	/**
+	 * Create contents of the button bar.
+	 * @param parent
+	 */
+	@Override
+	protected void createButtonsForButtonBar(Composite parent) {
+		createButton(parent, IDialogConstants.OK_ID, IDialogConstants.OK_LABEL, true);
+//		createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, false);
+	}
+
+	/**
+	 * Return the initial size of the dialog.
+	 */
+	@Override
+	protected Point getInitialSize() {
+		return new Point(600, 300);
+	}
+
+}

--- a/org.jcryptool.core/src/org/jcryptool/core/LanguageChooser.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/LanguageChooser.java
@@ -52,8 +52,7 @@ public class LanguageChooser extends Dialog {
 		btnEnglish.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				LanguageChooser.this.nl="en";
-				LanguageChooser.this.updateDialog();
+				LanguageChooser.this.nl = "en";
 			}
 		});
 		btnEnglish.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
@@ -66,16 +65,11 @@ public class LanguageChooser extends Dialog {
 		btnGerman.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
-				LanguageChooser.this.nl="de";
-				LanguageChooser.this.updateDialog();
+				LanguageChooser.this.nl = "de";
 			}
 		});
 
 		return container;
-	}
-
-	protected void updateDialog() {
-		// nothing to do for now; any state is valid...
 	}
 
 	/**
@@ -85,15 +79,8 @@ public class LanguageChooser extends Dialog {
 	@Override
 	protected void createButtonsForButtonBar(Composite parent) {
 		createButton(parent, IDialogConstants.OK_ID, IDialogConstants.OK_LABEL, true);
-//		createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, false);
+//      createButton(parent, IDialogConstants.CANCEL_ID, IDialogConstants.CANCEL_LABEL, false); // disable CANCEL button
 	}
 
-//	/**
-//	 * Return the initial size of the dialog.
-//	 */
-//	@Override
-//	protected Point getInitialSize() {
-//		return new Point(600, 300);
-//	}
 	
 }

--- a/org.jcryptool.core/src/org/jcryptool/core/LanguageChooser.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/LanguageChooser.java
@@ -41,7 +41,7 @@ public class LanguageChooser extends Dialog {
 		
 		lblNewLabel = new Label(container, SWT.WRAP);
 		lblNewLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
-		lblNewLabel.setText("JCrypTool is available only in English and German. Which language do you prefer?\nYou may change the Language later in 'Window -> Settings -> JCT General'.");
+		lblNewLabel.setText("JCrypTool is available only in English and German. Which language do you prefer?\nYou may change the language later in 'Window -> Settings -> JCT General'.");
 
 		lblNewLabel2 = new Label(container, SWT.WRAP);
 		lblNewLabel2.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));

--- a/org.jcryptool.core/src/org/jcryptool/core/LanguageChooser.java
+++ b/org.jcryptool.core/src/org/jcryptool/core/LanguageChooser.java
@@ -37,7 +37,7 @@ public class LanguageChooser extends Dialog {
 	protected Control createDialogArea(Composite parent) {
 		Composite container = (Composite) super.createDialogArea(parent);
 		container.setLayout(new GridLayout(1, false));
-		getShell().setText("Choose your Language");
+		getShell().setText("Choose your language");
 		
 		lblNewLabel = new Label(container, SWT.WRAP);
 		lblNewLabel.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));


### PR DESCRIPTION
Addresses #236; introduces a language chooser. 
![image](https://user-images.githubusercontent.com/982379/111155488-cb749000-8594-11eb-93f3-292f1cdd1986.png)


Removes French as language until we are sure that language works properly.
Objectives for code review:
- Code Review :P
- build JCT on your machine and start it a) normally, b) with `-nl jp`
- try to change the language in settings, test whether restarted JCT has the correct language.

Note, that in workspace builds, the restart is not (yet) possible, but fails with an appropriate message on `stderr`.
Thanks for reviewing.