### PR TITLE
Use fixed version and move away from Adopt

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,6 +33,6 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java }}
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: Build with Maven
       run: mvn clean package --file $GITHUB_WORKSPACE/core/org.jcryptool.releng/pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,6 +33,6 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java }}
-        distribution: 'temurin'
+        distribution: 'zulu'
     - name: Build with Maven
       run: mvn clean package --file $GITHUB_WORKSPACE/core/org.jcryptool.releng/pom.xml

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,9 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java: [ '11', '11.0.3' ]
     steps:
     - name: Checkout core repository
       uses: actions/checkout@v2
@@ -30,7 +32,7 @@ jobs:
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:
-        java-version: '11'
+        java-version: ${{ matrix.java }}
         distribution: 'adopt'
     - name: Build with Maven
       run: mvn clean package --file $GITHUB_WORKSPACE/core/org.jcryptool.releng/pom.xml


### PR DESCRIPTION
Best to do CI/CD against whatever is the latest version, e.g., 11, as well as a specific fixed version, e.g., 11.0.3. If the build fails and the fixed version is green, while the latest version is red, you will know that the problem is with the latest version and not with your application's code.

Adopt is no more, Temurin and Zulu are the available alternatives, and Zulu has more versions than Temurin, which is brand new while Zulu has been around for years. See also: https://github.com/geertjanw/core/actions

